### PR TITLE
Add occult feature for hidden line removal in G-code generation

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -437,6 +437,7 @@ async def convert_svg_to_gcode(project_id: str, request: SvgToGcodeRequest):
             "pen_mapping": request.pen_mapping,
             "origin_mode": getattr(request, "origin_mode", "lower_left"),
             "rotate_90": getattr(request, "rotate_90", False),
+            "enable_occult": getattr(request, "enable_occult", False),
         })
         # #endregion
         project = project_service.get_project(project_id)
@@ -485,6 +486,10 @@ async def convert_svg_to_gcode(project_id: str, request: SvgToGcodeRequest):
             rotate_90=getattr(request, "rotate_90", False),
             generation_tag=timecode,
             suppress_m0=getattr(request, "suppress_m0", False),
+            enable_occult=getattr(request, "enable_occult", False),
+            occult_ignore_layers=getattr(request, "occult_ignore_layers", False),
+            occult_across_layers_only=getattr(request, "occult_across_layers_only", False),
+            occult_keep_occulted=getattr(request, "occult_keep_occulted", False),
         )
 
         stored_name = str(Path("gcode") / gcode_filename)

--- a/backend/app/plotter_models.py
+++ b/backend/app/plotter_models.py
@@ -23,6 +23,10 @@ class SvgToGcodeRequest(BaseModel):
     origin_mode: Literal["lower_left", "center"] = "lower_left"
     rotate_90: bool = False
     suppress_m0: bool = False  # If True, skip M0 pen change commands (print in one color)
+    enable_occult: bool = False  # If True, remove hidden/occluded lines using vpype-occult
+    occult_ignore_layers: bool = False  # If True, perform occlusion across all layers (-i flag)
+    occult_across_layers_only: bool = False  # If True, only occlude across layers, not within (-a flag, overrides -i)
+    occult_keep_occulted: bool = False  # If True, keep removed lines in separate layer (-k flag)
 
 
 class GcodeAnalysisResult(BaseModel):

--- a/backend/requirements-windows.txt
+++ b/backend/requirements-windows.txt
@@ -15,6 +15,8 @@ aiofiles==23.2.1
 vpype[all]==1.15.0
 # Adds gcode export command for vpype
 vpype-gcode>=0.10.0
+# Adds hidden line removal (occult) command for vpype
+vpype-occult>=0.4.0
 
 # Alternative packages for Windows (uncomment if needed)
 # opencv-python==4.8.1.78

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,5 +16,7 @@ PyYAML==6.0.1
 vpype[all]==1.15.0
 # Adds gcode export command for vpype
 vpype-gcode>=0.10.0
+# Adds hidden line removal (occult) command for vpype
+vpype-occult>=0.4.0
 svgpathtools==1.6.1
 cairosvg>=2.7.0

--- a/frontend/src/components/EditProject.jsx
+++ b/frontend/src/components/EditProject.jsx
@@ -204,6 +204,10 @@ export default function EditProject({ currentProject }) {
     paperSize: "",
     rotate90: false,
     suppressM0: false,
+    enableOccult: false,
+    occultIgnoreLayers: false,
+    occultAcrossLayersOnly: false,
+    occultKeepOcculted: false,
   });
   const [convertLoading, setConvertLoading] = useState(false);
   const [convertError, setConvertError] = useState("");
@@ -565,6 +569,10 @@ export default function EditProject({ currentProject }) {
         origin_mode: "center",
         rotate_90: Boolean(convertOptions.rotate90),
         suppress_m0: Boolean(convertOptions.suppressM0),
+        enable_occult: Boolean(convertOptions.enableOccult),
+        occult_ignore_layers: Boolean(convertOptions.occultIgnoreLayers),
+        occult_across_layers_only: Boolean(convertOptions.occultAcrossLayersOnly),
+        occult_keep_occulted: Boolean(convertOptions.occultKeepOcculted),
       });
       await loadAssets();
       setConvertDialogOpen(false);
@@ -1885,6 +1893,85 @@ export default function EditProject({ currentProject }) {
               }
               label="Suppress M0 pen changes (print in one color)"
             />
+
+            <Divider sx={{ my: 2 }} />
+
+            <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
+              Hidden Line Removal (Occult)
+            </Typography>
+
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={convertOptions.enableOccult}
+                  onChange={(e) =>
+                    setConvertOptions((prev) => ({
+                      ...prev,
+                      enableOccult: e.target.checked,
+                    }))
+                  }
+                  color="primary"
+                />
+              }
+              label="Enable hidden line removal (occult)"
+            />
+
+            {convertOptions.enableOccult && (
+              <Box sx={{ pl: 3, mt: 1 }}>
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={convertOptions.occultIgnoreLayers}
+                      onChange={(e) =>
+                        setConvertOptions((prev) => ({
+                          ...prev,
+                          occultIgnoreLayers: e.target.checked,
+                          occultAcrossLayersOnly: e.target.checked
+                            ? false
+                            : prev.occultAcrossLayersOnly,
+                        }))
+                      }
+                      disabled={convertOptions.occultAcrossLayersOnly}
+                      color="primary"
+                    />
+                  }
+                  label="Ignore layers (-i) - Perform occlusion across all layers"
+                />
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={convertOptions.occultAcrossLayersOnly}
+                      onChange={(e) =>
+                        setConvertOptions((prev) => ({
+                          ...prev,
+                          occultAcrossLayersOnly: e.target.checked,
+                          occultIgnoreLayers: e.target.checked
+                            ? false
+                            : prev.occultIgnoreLayers,
+                        }))
+                      }
+                      color="primary"
+                    />
+                  }
+                  label="Across layers only (-a) - Only occlude across layers, not within"
+                />
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={convertOptions.occultKeepOcculted}
+                      onChange={(e) =>
+                        setConvertOptions((prev) => ({
+                          ...prev,
+                          occultKeepOcculted: e.target.checked,
+                        }))
+                      }
+                      color="primary"
+                    />
+                  }
+                  label="Keep occulted lines (-k) - Keep removed lines in separate layer"
+                />
+              </Box>
+            )}
 
             {/* Fit/center and pen mapping removed; we always center without pen mapping. */}
 


### PR DESCRIPTION
- Introduced new options in SvgToGcodeRequest and the convert_svg_to_gcode function to enable hidden line removal using vpype-occult.
- Updated the EditProject component to include UI controls for occult settings, allowing users to customize hidden line removal behavior.
- Enhanced G-code header comments to reflect occult settings when enabled, improving user awareness of the applied configurations.