### PR TITLE
Fix jog controls to use relative moves (#17)

### DIFF
--- a/frontend/src/components/ControlPanel.jsx
+++ b/frontend/src/components/ControlPanel.jsx
@@ -839,11 +839,14 @@ export default function ControlPanel({ currentProject }) {
       showSnackbar("Please connect to plotter first", "warning");
       return;
     }
-    try {
-      // Use current motion mode - don't switch modes, just move
-      await sendGcodeCommand(`G0 X${x} Y${y}`);
-    } catch (err) {
-      showSnackbar(`Movement error: ${err.message}`, "error");
+    const activeMode = motionMode || "relative";
+    const requiresRestore = activeMode !== "relative";
+    if (requiresRestore) {
+      await sendCommand("G91");
+    }
+    await sendCommand(`G0 X${x} Y${y}`);
+    if (requiresRestore) {
+      await sendCommand("G90");
     }
   };
 


### PR DESCRIPTION
## Summary
- force jog moves to run in relative mode and restore the previous motion mode
- keep jog step labels consistent with behavior in absolute mode

## Test plan
- not run (manual): toggle to Absolute and press 10-step jog; expect +10 move