### PR TITLE
Remote server installation timeout

### DIFF
--- a/DEBUGGING_GUIDE.md
+++ b/DEBUGGING_GUIDE.md
@@ -223,6 +223,28 @@ If you need to debug from a different machine:
 2. **Ensure firewall allows** debug ports (5678, 9229)
 3. **Use SSH tunneling** if needed
 
+### Cursor Remote (SSH) install timeout
+If Cursor reports "Failed to install server within the timeout", try:
+
+1. **Increase the install timeout** in Cursor settings:
+   ```json
+   {
+     "remote.SSH.serverInstallTimeout": 120
+   }
+   ```
+   Use a larger value on slower ARM boards (e.g., 300 seconds).
+2. **Check the remote log file** for a more specific error:
+   ```bash
+   ls /run/user/<uid>/cursor-remote-code.log.*
+   ```
+3. **Verify disk space and permissions** on the remote host:
+   - Ensure `~/.cursor-server` is writable
+   - Confirm there is enough free space in the home directory
+4. **Clear partial installs** if needed:
+   ```bash
+   rm -rf ~/.cursor-server/bin
+   ```
+
 ### Production Debugging
 For debugging production issues:
 


### PR DESCRIPTION
Add a troubleshooting section to `DEBUGGING_GUIDE.md` for Cursor Remote (SSH) install timeouts.

---
<a href="https://cursor.com/background-agent?bcId=bc-5be39302-f85a-4bae-bf70-63d14b7db776"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5be39302-f85a-4bae-bf70-63d14b7db776"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

