### PR TITLE
Configure draw speed for G-code

### DIFF
--- a/backend/app/config_models.py
+++ b/backend/app/config_models.py
@@ -10,6 +10,12 @@ class GcodeSettings(BaseModel):
     before_print: List[str] = Field(default_factory=list, description="Commands to run just before starting a print job")
     pen_up_command: str = Field(default="M280 P0 S110", description="Command to raise pen")
     pen_down_command: str = Field(default="M280 P0 S130", description="Command to lower pen")
+    draw_speed: float = Field(
+        default=2000.0,
+        ge=500.0,
+        le=8000.0,
+        description="Drawing feed rate in mm/min used for G-code generation",
+    )
     servo_delay_ms: float = Field(default=100.0, description="Delay in milliseconds after servo commands to allow settling (reduces bouncing)")
 
 
@@ -19,6 +25,12 @@ class GcodeSettingsUpdate(BaseModel):
     before_print: Optional[List[str]] = Field(None, description="Commands to run before print start")
     pen_up_command: Optional[str] = Field(None, description="Command to raise pen")
     pen_down_command: Optional[str] = Field(None, description="Command to lower pen")
+    draw_speed: Optional[float] = Field(
+        None,
+        ge=500.0,
+        le=8000.0,
+        description="Drawing feed rate in mm/min used for G-code generation",
+    )
     servo_delay_ms: Optional[float] = Field(None, description="Delay in milliseconds after servo commands to allow settling")
 
 

--- a/backend/app/config_service.py
+++ b/backend/app/config_service.py
@@ -368,8 +368,18 @@ class ConfigurationService:
             ],
             "pen_up_command": "M280 P0 S110",
             "pen_down_command": "M280 P0 S130",
+            "draw_speed": 2000.0,
             "servo_delay_ms": 100.0,
         }
+
+    @staticmethod
+    def _normalize_draw_speed(value: Optional[float]) -> float:
+        """Clamp draw speed to a safe range (mm/min)."""
+        try:
+            speed = float(value)
+        except (TypeError, ValueError):
+            return 2000.0
+        return min(max(speed, 500.0), 8000.0)
     
     def _validate_and_repair_config(self):
         """Validate and repair configuration to ensure all required fields exist"""
@@ -432,6 +442,12 @@ class ConfigurationService:
                     else:
                         plotter[field] = 'Unknown'
                     needs_repair = True
+
+            gcode_sequences = plotter.get('gcode_sequences', {})
+            if 'draw_speed' not in gcode_sequences:
+                gcode_sequences['draw_speed'] = 2000.0
+                plotter['gcode_sequences'] = gcode_sequences
+                needs_repair = True
         
         # Ensure all papers have required fields
         for paper in self.config_data.get('papers', []):
@@ -539,8 +555,20 @@ class ConfigurationService:
                 update_data = plotter_data.dict(exclude_unset=True)
                 pen_up_override = update_data.pop("gcode_pen_up_command", None)
                 pen_down_override = update_data.pop("gcode_pen_down_command", None)
-                if pen_up_override is not None or pen_down_override is not None:
-                    existing_sequences = plotter.get('gcode_sequences', self._get_default_gcode_sequences())
+                if (
+                    pen_up_override is not None
+                    or pen_down_override is not None
+                    or "gcode_sequences" in update_data
+                ):
+                    existing_sequences = dict(
+                        plotter.get('gcode_sequences', self._get_default_gcode_sequences())
+                    )
+                    incoming_sequences = update_data.pop("gcode_sequences", None)
+                    if incoming_sequences is not None:
+                        if isinstance(incoming_sequences, dict):
+                            existing_sequences.update(incoming_sequences)
+                        else:
+                            existing_sequences.update(incoming_sequences.dict(exclude_unset=True))
                     if pen_up_override is not None:
                         existing_sequences['pen_up_command'] = pen_up_override
                     if pen_down_override is not None:
@@ -686,6 +714,7 @@ class ConfigurationService:
             before_print=defaults.get("before_print", []),
             pen_up_command=defaults.get("pen_up_command", "M280 P0 S110"),
             pen_down_command=defaults.get("pen_down_command", "M280 P0 S130"),
+            draw_speed=self._normalize_draw_speed(defaults.get("draw_speed", 2000.0)),
             servo_delay_ms=defaults.get("servo_delay_ms", 100.0),
         )
 
@@ -743,6 +772,7 @@ class ConfigurationService:
                 before_print=gcode_data.get('before_print', []),
                 pen_up_command=gcode_data.get('pen_up_command', "M280 P0 S110"),
                 pen_down_command=gcode_data.get('pen_down_command', "M280 P0 S130"),
+                draw_speed=self._normalize_draw_speed(gcode_data.get('draw_speed', 2000.0)),
                 servo_delay_ms=gcode_data.get('servo_delay_ms', 100.0),
             ),
             home_position_x=plotter_dict['home_position_x'],
@@ -784,6 +814,7 @@ class ConfigurationService:
                     before_print=gcode_data.get('before_print', []),
                     pen_up_command=pen_up,
                     pen_down_command=pen_down,
+                    draw_speed=self._normalize_draw_speed(gcode_data.get('draw_speed', 2000.0)),
                     servo_delay_ms=gcode_data.get('servo_delay_ms', 100.0),
                 )
         return None
@@ -807,6 +838,9 @@ class ConfigurationService:
                 if 'pen_down_command' in update_payload:
                     if update_payload['pen_down_command'] is not None:
                         existing['pen_down_command'] = update_payload['pen_down_command']
+                if 'draw_speed' in update_payload:
+                    if update_payload['draw_speed'] is not None:
+                        existing['draw_speed'] = self._normalize_draw_speed(update_payload['draw_speed'])
                 if 'servo_delay_ms' in update_payload:
                     if update_payload['servo_delay_ms'] is not None:
                         existing['servo_delay_ms'] = update_payload['servo_delay_ms']

--- a/backend/app/vpype_converter.py
+++ b/backend/app/vpype_converter.py
@@ -466,6 +466,15 @@ def build_vpype_config_content(
     pen_down = getattr(gcode, "pen_down_command", "M280 P0 S130")
     if pen_down is None:
         pen_down = "M280 P0 S130"
+    draw_speed = getattr(gcode, "draw_speed", None)
+    if draw_speed is None:
+        draw_speed = 2000.0
+    try:
+        draw_speed = float(draw_speed)
+    except (TypeError, ValueError):
+        draw_speed = 2000.0
+    draw_speed = min(max(draw_speed, 500.0), 8000.0)
+    draw_feed = f"{draw_speed:g}"
     if servo_delay_ms is None:
         servo_delay_ms = 100.0
     if pen_debounce_steps is None or pen_debounce_steps < 1:
@@ -508,17 +517,19 @@ document_start = """
 linecollection_start = "{pen_up}\\n"
 
 # First segment in a path: move then pen down (exponential approach to reduce bouncing)
+# Set draw feed once after pen down.
 segment_first = """
 G0 X{{x:.3f}} Y{{y:.3f}}
 {pen_down_sequence}
+G1 F{draw_feed}
 """
 
 # Subsequent segments while drawing
-segment = "G1 X{{x:.3f}} Y{{y:.3f}} F1500\\n"
+segment = "G1 X{{x:.3f}} Y{{y:.3f}}\\n"
 
 # Last segment in a path: finish move then pen up
 segment_last = """
-G1 X{{x:.3f}} Y{{y:.3f}} F1500
+G1 X{{x:.3f}} Y{{y:.3f}}
 {pen_up}
 """
 
@@ -620,7 +631,7 @@ def insert_m0_pen_changes(
     # Collection starts (linecollection_start) are pen_up commands that appear:
     # - On their own line (not part of segment_last multiline block)
     # - After we've seen at least one drawing command (G0/G1)
-    # - segment_last has format: "G1 X... Y... F1500\n{pen_up}" (pen_up on next line)
+    # - segment_last has format: "G1 X... Y... F<feed>\n{pen_up}" (pen_up on next line)
     # - document_start pen_up appears BEFORE any G0/G1 commands
     
     collection_count = 0
@@ -686,7 +697,7 @@ def insert_m0_pen_changes(
             else:
                 # After drawing has started, check if this is a collection start
                 # Pattern analysis:
-                # - segment_last: G1 ... F1500, then M280 (path end pen_up) - pen_up immediately after G1
+                # - segment_last: G1 ... F<feed>, then M280 (path end pen_up) - pen_up immediately after G1
                 # - linecollection_start: M280 (collection start pen_up), then G0 ... (first segment of next path)
                 # So: if previous line is G1, this is path end (segment_last)
                 #     if next line is G0, this is collection start (linecollection_start)

--- a/frontend/src/components/GcodeSettings.jsx
+++ b/frontend/src/components/GcodeSettings.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { Bolt as BoltIcon, Save as SaveIcon } from "@mui/icons-material";
 import {
   Alert,
   Box,
@@ -10,11 +10,12 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
+import React, { useEffect, useState } from "react";
 import {
-  Save as SaveIcon,
-  Bolt as BoltIcon,
-} from "@mui/icons-material";
-import { getGcodeSettings, updateGcodeSettings, runPrePrintGcode } from "../services/apiService";
+  getGcodeSettings,
+  runPrePrintGcode,
+  updateGcodeSettings,
+} from "../services/apiService";
 
 /**
  * GcodeSettings allows configuring automatic G-code sent on connect and before print start.
@@ -22,9 +23,14 @@ import { getGcodeSettings, updateGcodeSettings, runPrePrintGcode } from "../serv
 export default function GcodeSettings() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-  const [settings, setSettings] = useState({ on_connect: [], before_print: [] });
+  const [settings, setSettings] = useState({
+    on_connect: [],
+    before_print: [],
+    draw_speed: 2000,
+  });
   const [onConnectText, setOnConnectText] = useState("");
   const [beforePrintText, setBeforePrintText] = useState("");
+  const [drawSpeed, setDrawSpeed] = useState("2000");
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(null);
   const [runningPrePrint, setRunningPrePrint] = useState(false);
@@ -53,11 +59,29 @@ export default function GcodeSettings() {
       setSettings(result);
       setOnConnectText(toMultiline(result.on_connect));
       setBeforePrintText(toMultiline(result.before_print));
+      setDrawSpeed(
+        result.draw_speed !== undefined && result.draw_speed !== null
+          ? String(result.draw_speed)
+          : "2000",
+      );
     } catch (err) {
       setError(err.message);
     } finally {
       setLoading(false);
     }
+  };
+
+  const parseDrawSpeed = () => {
+    const value = Number(drawSpeed);
+    if (Number.isNaN(value)) {
+      setError("Draw speed must be a number.");
+      return null;
+    }
+    if (value < 500 || value > 8000) {
+      setError("Draw speed must be between 500 and 8000 mm/min.");
+      return null;
+    }
+    return value;
   };
 
   const handleSave = async () => {
@@ -66,9 +90,15 @@ export default function GcodeSettings() {
       setSuccess(null);
       setError(null);
 
+      const speedValue = parseDrawSpeed();
+      if (speedValue === null) {
+        return;
+      }
+
       const payload = {
         on_connect: normalizeCommands(onConnectText),
         before_print: normalizeCommands(beforePrintText),
+        draw_speed: speedValue,
       };
 
       const updated = await updateGcodeSettings(payload);
@@ -89,7 +119,9 @@ export default function GcodeSettings() {
       const result = await runPrePrintGcode();
       setPrePrintResult(result);
       if (!result.success) {
-        setError("One or more pre-print commands failed. Check the command log.");
+        setError(
+          "One or more pre-print commands failed. Check the command log.",
+        );
       }
     } catch (err) {
       setError(err.message);
@@ -100,7 +132,12 @@ export default function GcodeSettings() {
 
   if (loading) {
     return (
-      <Box display="flex" justifyContent="center" alignItems="center" minHeight="200px">
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        minHeight="200px"
+      >
         <CircularProgress />
       </Box>
     );
@@ -114,14 +151,34 @@ export default function GcodeSettings() {
             Automatic G-code
           </Typography>
           <Typography variant="body2" color="text.secondary">
-            Define commands that run automatically. Use one command per line; empty lines are ignored.
+            Define commands that run automatically. Use one command per line;
+            empty lines are ignored.
           </Typography>
         </Box>
 
-        {error && <Alert severity="error" onClose={() => setError(null)}>{error}</Alert>}
-        {success && <Alert severity="success" onClose={() => setSuccess(null)}>{success}</Alert>}
+        {error && (
+          <Alert severity="error" onClose={() => setError(null)}>
+            {error}
+          </Alert>
+        )}
+        {success && (
+          <Alert severity="success" onClose={() => setSuccess(null)}>
+            {success}
+          </Alert>
+        )}
 
         <Grid container spacing={3}>
+          <Grid item xs={12}>
+            <TextField
+              label="Draw Speed (mm/min)"
+              type="number"
+              fullWidth
+              value={drawSpeed}
+              onChange={(e) => setDrawSpeed(e.target.value)}
+              helperText="Used for generated G-code drawing moves (500-8000)."
+              inputProps={{ min: 500, max: 8000, step: 50 }}
+            />
+          </Grid>
           <Grid item xs={12} md={6}>
             <TextField
               label="On Connect"
@@ -179,7 +236,8 @@ export default function GcodeSettings() {
             - Use absolute (`G90`) or relative (`G91`) positioning explicitly.
           </Typography>
           <Typography variant="body2" color="text.secondary">
-            - Include units (`G20` inches or `G21` millimeters) to avoid surprises.
+            - Include units (`G20` inches or `G21` millimeters) to avoid
+            surprises.
           </Typography>
           <Typography variant="body2" color="text.secondary">
             - Keep homing or pen-up commands here to standardize every session.
@@ -189,4 +247,3 @@ export default function GcodeSettings() {
     </Paper>
   );
 }
-

--- a/frontend/src/components/PlotterConfiguration.jsx
+++ b/frontend/src/components/PlotterConfiguration.jsx
@@ -1,53 +1,53 @@
 import {
-    Add as AddIcon,
-    Delete as DeleteIcon,
-    Edit as EditIcon,
-    StarBorder as StarBorderIcon,
-    Star as StarIcon,
-} from '@mui/icons-material';
+  Add as AddIcon,
+  Delete as DeleteIcon,
+  Edit as EditIcon,
+  StarBorder as StarBorderIcon,
+  Star as StarIcon,
+} from "@mui/icons-material";
 import {
-    Alert,
-    Box,
-    Button,
-    Checkbox,
-    Chip,
-    CircularProgress,
-    Dialog,
-    DialogActions,
-    DialogContent,
-    DialogTitle,
-    Divider,
-    FormControl,
-    FormControlLabel,
-    FormHelperText,
-    Grid,
-    IconButton,
-    InputLabel,
-    MenuItem,
-    Paper,
-    Select,
-    Snackbar,
-    Table,
-    TableBody,
-    TableCell,
-    TableContainer,
-    TableHead,
-    TableRow,
-    TextField,
-    Typography
-} from '@mui/material';
-import React, { useEffect, useState } from 'react';
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  FormControl,
+  FormControlLabel,
+  FormHelperText,
+  Grid,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  Snackbar,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from "@mui/material";
+import React, { useEffect, useState } from "react";
 import {
-    createPlotter,
-    deletePlotter,
-    getPlotters,
-    updatePlotter
-} from '../services/apiService';
+  createPlotter,
+  deletePlotter,
+  getPlotters,
+  updatePlotter,
+} from "../services/apiService";
 
 const PLOTTER_TYPES = [
-  { value: 'polargraph', label: 'Polargraph' },
-  { value: 'xy_plotter', label: 'XY Plotter' },
-  { value: 'pen_plotter', label: 'Pen Plotter' },
+  { value: "polargraph", label: "Polargraph" },
+  { value: "xy_plotter", label: "XY Plotter" },
+  { value: "pen_plotter", label: "Pen Plotter" },
 ];
 
 export default function PlotterConfiguration() {
@@ -61,8 +61,8 @@ export default function PlotterConfiguration() {
   const [deleteTarget, setDeleteTarget] = useState(null);
   const [deleting, setDeleting] = useState(false);
   const [formData, setFormData] = useState({
-    name: '',
-    plotter_type: 'polargraph',
+    name: "",
+    plotter_type: "polargraph",
     width: 1000,
     height: 1000,
     mm_per_rev: 95.0,
@@ -72,17 +72,18 @@ export default function PlotterConfiguration() {
     pen_up_position: 10.0,
     pen_down_position: 0.0,
     pen_speed: 20.0,
-    gcode_pen_up_command: 'M280 P0 S110',
-    gcode_pen_down_command: 'M280 P0 S130',
-    gcode_on_connect: '',
-    gcode_before_print: '',
+    gcode_pen_up_command: "M280 P0 S110",
+    gcode_pen_down_command: "M280 P0 S130",
+    gcode_draw_speed: 2000,
+    gcode_on_connect: "",
+    gcode_before_print: "",
     home_position_x: 0.0,
     home_position_y: 0.0,
     is_default: false,
   });
 
   const notifyPlotterConfigUpdated = () => {
-    window.dispatchEvent(new Event('pv_plotter_config_updated'));
+    window.dispatchEvent(new Event("pv_plotter_config_updated"));
   };
 
   useEffect(() => {
@@ -99,7 +100,7 @@ export default function PlotterConfiguration() {
         setPlotters(response.plotters || []);
       }
     } catch (err) {
-      setError('Failed to load plotters');
+      setError("Failed to load plotters");
     } finally {
       setLoading(false);
     }
@@ -108,8 +109,8 @@ export default function PlotterConfiguration() {
   const handleCreate = () => {
     setEditingPlotter(null);
     setFormData({
-      name: '',
-      plotter_type: 'polargraph',
+      name: "",
+      plotter_type: "polargraph",
       width: 1000,
       height: 1000,
       mm_per_rev: 95.0,
@@ -119,10 +120,11 @@ export default function PlotterConfiguration() {
       pen_up_position: 10.0,
       pen_down_position: 0.0,
       pen_speed: 20.0,
-      gcode_pen_up_command: 'M280 P0 S110',
-      gcode_pen_down_command: 'M280 P0 S130',
-      gcode_on_connect: '',
-      gcode_before_print: '',
+      gcode_pen_up_command: "M280 P0 S110",
+      gcode_pen_down_command: "M280 P0 S130",
+      gcode_draw_speed: 2000,
+      gcode_on_connect: "",
+      gcode_before_print: "",
       home_position_x: 0.0,
       home_position_y: 0.0,
       is_default: false,
@@ -144,10 +146,15 @@ export default function PlotterConfiguration() {
       pen_up_position: plotter.pen_up_position,
       pen_down_position: plotter.pen_down_position,
       pen_speed: plotter.pen_speed,
-      gcode_pen_up_command: plotter.gcode_sequences?.pen_up_command || 'M280 P0 S110',
-      gcode_pen_down_command: plotter.gcode_sequences?.pen_down_command || 'M280 P0 S130',
-      gcode_on_connect: (plotter.gcode_sequences?.on_connect || []).join('\n'),
-      gcode_before_print: (plotter.gcode_sequences?.before_print || []).join('\n'),
+      gcode_pen_up_command:
+        plotter.gcode_sequences?.pen_up_command || "M280 P0 S110",
+      gcode_pen_down_command:
+        plotter.gcode_sequences?.pen_down_command || "M280 P0 S130",
+      gcode_draw_speed: plotter.gcode_sequences?.draw_speed ?? 2000,
+      gcode_on_connect: (plotter.gcode_sequences?.on_connect || []).join("\n"),
+      gcode_before_print: (plotter.gcode_sequences?.before_print || []).join(
+        "\n",
+      ),
       home_position_x: plotter.home_position_x,
       home_position_y: plotter.home_position_y,
       is_default: plotter.is_default,
@@ -160,18 +167,27 @@ export default function PlotterConfiguration() {
       const payload = {
         ...formData,
         gcode_sequences: {
-          on_connect: (formData.gcode_on_connect || '').split('\n').map((s) => s.trim()).filter(Boolean),
-          before_print: (formData.gcode_before_print || '').split('\n').map((s) => s.trim()).filter(Boolean),
-          pen_up_command: formData.gcode_pen_up_command || 'M280 P0 S110',
-          pen_down_command: formData.gcode_pen_down_command || 'M280 P0 S130',
+          on_connect: (formData.gcode_on_connect || "")
+            .split("\n")
+            .map((s) => s.trim())
+            .filter(Boolean),
+          before_print: (formData.gcode_before_print || "")
+            .split("\n")
+            .map((s) => s.trim())
+            .filter(Boolean),
+          pen_up_command: formData.gcode_pen_up_command || "M280 P0 S110",
+          pen_down_command: formData.gcode_pen_down_command || "M280 P0 S130",
+          draw_speed: Number.isFinite(formData.gcode_draw_speed)
+            ? formData.gcode_draw_speed
+            : 2000,
         },
       };
       if (editingPlotter) {
         await updatePlotter(editingPlotter.id, payload);
-        setSuccess('Plotter updated successfully');
+        setSuccess("Plotter updated successfully");
       } else {
         await createPlotter(payload);
-        setSuccess('Plotter created successfully');
+        setSuccess("Plotter created successfully");
       }
       setDialogOpen(false);
       notifyPlotterConfigUpdated();
@@ -198,7 +214,7 @@ export default function PlotterConfiguration() {
     try {
       setDeleting(true);
       await deletePlotter(deleteTarget.id);
-      setSuccess('Plotter deleted successfully');
+      setSuccess("Plotter deleted successfully");
       notifyPlotterConfigUpdated();
       setDeleteDialogOpen(false);
       setDeleteTarget(null);
@@ -223,7 +239,12 @@ export default function PlotterConfiguration() {
 
   if (loading) {
     return (
-      <Box display="flex" justifyContent="center" alignItems="center" minHeight="200px">
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        minHeight="200px"
+      >
         <CircularProgress />
       </Box>
     );
@@ -231,7 +252,12 @@ export default function PlotterConfiguration() {
 
   return (
     <Box>
-      <Box display="flex" justifyContent="space-between" alignItems="center" mb={3}>
+      <Box
+        display="flex"
+        justifyContent="space-between"
+        alignItems="center"
+        mb={3}
+      >
         <Typography variant="h6">Plotter Configurations</Typography>
         <Button
           variant="contained"
@@ -261,13 +287,20 @@ export default function PlotterConfiguration() {
                 <TableCell>
                   <Chip label={plotter.plotter_type} size="small" />
                 </TableCell>
-                <TableCell>{plotter.width} × {plotter.height}</TableCell>
+                <TableCell>
+                  {plotter.width} × {plotter.height}
+                </TableCell>
                 <TableCell>
                   {plotter.mm_per_rev}mm/rev, {plotter.steps_per_rev} steps/rev
                 </TableCell>
                 <TableCell>
                   {plotter.is_default ? (
-                    <Chip icon={<StarIcon />} label="Default" color="primary" size="small" />
+                    <Chip
+                      icon={<StarIcon />}
+                      label="Default"
+                      color="primary"
+                      size="small"
+                    />
                   ) : (
                     <IconButton
                       size="small"
@@ -302,22 +335,31 @@ export default function PlotterConfiguration() {
       </TableContainer>
 
       {/* Add/Edit Dialog */}
-      <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} maxWidth="md" fullWidth>
+      <Dialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        maxWidth="md"
+        fullWidth
+      >
         <DialogTitle>
-          {editingPlotter ? 'Edit Plotter' : 'Add New Plotter'}
+          {editingPlotter ? "Edit Plotter" : "Add New Plotter"}
         </DialogTitle>
         <DialogContent>
           <Grid container spacing={2} sx={{ mt: 1 }}>
             {/* Basic Information */}
             <Grid item xs={12}>
-              <Typography variant="h6" gutterBottom>Basic Information</Typography>
+              <Typography variant="h6" gutterBottom>
+                Basic Information
+              </Typography>
             </Grid>
             <Grid item xs={12} sm={6}>
               <TextField
                 fullWidth
                 label="Name"
                 value={formData.name}
-                onChange={(e) => setFormData(prev => ({ ...prev, name: e.target.value }))}
+                onChange={(e) =>
+                  setFormData((prev) => ({ ...prev, name: e.target.value }))
+                }
                 required
               />
             </Grid>
@@ -326,7 +368,12 @@ export default function PlotterConfiguration() {
                 <InputLabel>Plotter Type</InputLabel>
                 <Select
                   value={formData.plotter_type}
-                  onChange={(e) => setFormData(prev => ({ ...prev, plotter_type: e.target.value }))}
+                  onChange={(e) =>
+                    setFormData((prev) => ({
+                      ...prev,
+                      plotter_type: e.target.value,
+                    }))
+                  }
                   label="Plotter Type"
                 >
                   {PLOTTER_TYPES.map((type) => (
@@ -344,7 +391,9 @@ export default function PlotterConfiguration() {
 
             {/* Dimensions */}
             <Grid item xs={12}>
-              <Typography variant="h6" gutterBottom>Dimensions</Typography>
+              <Typography variant="h6" gutterBottom>
+                Dimensions
+              </Typography>
             </Grid>
             <Grid item xs={12} sm={6}>
               <TextField
@@ -352,7 +401,12 @@ export default function PlotterConfiguration() {
                 label="Width (mm)"
                 type="number"
                 value={formData.width}
-                onChange={(e) => setFormData(prev => ({ ...prev, width: parseFloat(e.target.value) || 0 }))}
+                onChange={(e) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    width: parseFloat(e.target.value) || 0,
+                  }))
+                }
                 required
               />
             </Grid>
@@ -362,7 +416,12 @@ export default function PlotterConfiguration() {
                 label="Height (mm)"
                 type="number"
                 value={formData.height}
-                onChange={(e) => setFormData(prev => ({ ...prev, height: parseFloat(e.target.value) || 0 }))}
+                onChange={(e) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    height: parseFloat(e.target.value) || 0,
+                  }))
+                }
                 required
               />
             </Grid>
@@ -373,7 +432,9 @@ export default function PlotterConfiguration() {
 
             {/* Motor Settings */}
             <Grid item xs={12}>
-              <Typography variant="h6" gutterBottom>Motor Settings</Typography>
+              <Typography variant="h6" gutterBottom>
+                Motor Settings
+              </Typography>
             </Grid>
             <Grid item xs={12} sm={6}>
               <TextField
@@ -381,7 +442,12 @@ export default function PlotterConfiguration() {
                 label="mm per revolution"
                 type="number"
                 value={formData.mm_per_rev}
-                onChange={(e) => setFormData(prev => ({ ...prev, mm_per_rev: parseFloat(e.target.value) || 0 }))}
+                onChange={(e) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    mm_per_rev: parseFloat(e.target.value) || 0,
+                  }))
+                }
                 required
               />
             </Grid>
@@ -391,7 +457,12 @@ export default function PlotterConfiguration() {
                 label="Steps per revolution"
                 type="number"
                 value={formData.steps_per_rev}
-                onChange={(e) => setFormData(prev => ({ ...prev, steps_per_rev: parseFloat(e.target.value) || 0 }))}
+                onChange={(e) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    steps_per_rev: parseFloat(e.target.value) || 0,
+                  }))
+                }
                 required
               />
             </Grid>
@@ -402,7 +473,9 @@ export default function PlotterConfiguration() {
 
             {/* Speed Settings */}
             <Grid item xs={12}>
-              <Typography variant="h6" gutterBottom>Speed Settings</Typography>
+              <Typography variant="h6" gutterBottom>
+                Speed Settings
+              </Typography>
             </Grid>
             <Grid item xs={12} sm={6}>
               <TextField
@@ -410,7 +483,12 @@ export default function PlotterConfiguration() {
                 label="Max Speed (mm/s)"
                 type="number"
                 value={formData.max_speed}
-                onChange={(e) => setFormData(prev => ({ ...prev, max_speed: parseFloat(e.target.value) || 0 }))}
+                onChange={(e) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    max_speed: parseFloat(e.target.value) || 0,
+                  }))
+                }
                 required
               />
             </Grid>
@@ -420,7 +498,12 @@ export default function PlotterConfiguration() {
                 label="Acceleration (mm/s²)"
                 type="number"
                 value={formData.acceleration}
-                onChange={(e) => setFormData(prev => ({ ...prev, acceleration: parseFloat(e.target.value) || 0 }))}
+                onChange={(e) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    acceleration: parseFloat(e.target.value) || 0,
+                  }))
+                }
                 required
               />
             </Grid>
@@ -431,7 +514,9 @@ export default function PlotterConfiguration() {
 
             {/* Pen Settings */}
             <Grid item xs={12}>
-              <Typography variant="h6" gutterBottom>Pen Settings</Typography>
+              <Typography variant="h6" gutterBottom>
+                Pen Settings
+              </Typography>
             </Grid>
             <Grid item xs={12} sm={4}>
               <TextField
@@ -439,7 +524,12 @@ export default function PlotterConfiguration() {
                 label="Pen Up Position (mm)"
                 type="number"
                 value={formData.pen_up_position}
-                onChange={(e) => setFormData(prev => ({ ...prev, pen_up_position: parseFloat(e.target.value) || 0 }))}
+                onChange={(e) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    pen_up_position: parseFloat(e.target.value) || 0,
+                  }))
+                }
                 required
               />
             </Grid>
@@ -449,7 +539,12 @@ export default function PlotterConfiguration() {
                 label="Pen Down Position (mm)"
                 type="number"
                 value={formData.pen_down_position}
-                onChange={(e) => setFormData(prev => ({ ...prev, pen_down_position: parseFloat(e.target.value) || 0 }))}
+                onChange={(e) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    pen_down_position: parseFloat(e.target.value) || 0,
+                  }))
+                }
                 required
               />
             </Grid>
@@ -459,7 +554,12 @@ export default function PlotterConfiguration() {
                 label="Pen Speed (mm/s)"
                 type="number"
                 value={formData.pen_speed}
-                onChange={(e) => setFormData(prev => ({ ...prev, pen_speed: parseFloat(e.target.value) || 0 }))}
+                onChange={(e) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    pen_speed: parseFloat(e.target.value) || 0,
+                  }))
+                }
                 required
               />
             </Grid>
@@ -469,7 +569,12 @@ export default function PlotterConfiguration() {
                 fullWidth
                 label="Pen Up Command"
                 value={formData.gcode_pen_up_command}
-                onChange={(e) => setFormData(prev => ({ ...prev, gcode_pen_up_command: e.target.value }))}
+                onChange={(e) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    gcode_pen_up_command: e.target.value,
+                  }))
+                }
                 helperText="Command sent to raise the pen (e.g., servo angle)"
               />
             </Grid>
@@ -478,7 +583,12 @@ export default function PlotterConfiguration() {
                 fullWidth
                 label="Pen Down Command"
                 value={formData.gcode_pen_down_command}
-                onChange={(e) => setFormData(prev => ({ ...prev, gcode_pen_down_command: e.target.value }))}
+                onChange={(e) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    gcode_pen_down_command: e.target.value,
+                  }))
+                }
                 helperText="Command sent to lower the pen"
               />
             </Grid>
@@ -489,7 +599,9 @@ export default function PlotterConfiguration() {
 
             {/* Home Position */}
             <Grid item xs={12}>
-              <Typography variant="h6" gutterBottom>Home Position</Typography>
+              <Typography variant="h6" gutterBottom>
+                Home Position
+              </Typography>
             </Grid>
             <Grid item xs={12} sm={6}>
               <TextField
@@ -497,7 +609,12 @@ export default function PlotterConfiguration() {
                 label="Home X (mm)"
                 type="number"
                 value={formData.home_position_x}
-                onChange={(e) => setFormData(prev => ({ ...prev, home_position_x: parseFloat(e.target.value) || 0 }))}
+                onChange={(e) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    home_position_x: parseFloat(e.target.value) || 0,
+                  }))
+                }
                 required
               />
             </Grid>
@@ -507,7 +624,12 @@ export default function PlotterConfiguration() {
                 label="Home Y (mm)"
                 type="number"
                 value={formData.home_position_y}
-                onChange={(e) => setFormData(prev => ({ ...prev, home_position_y: parseFloat(e.target.value) || 0 }))}
+                onChange={(e) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    home_position_y: parseFloat(e.target.value) || 0,
+                  }))
+                }
                 required
               />
             </Grid>
@@ -518,10 +640,29 @@ export default function PlotterConfiguration() {
 
             {/* Automatic G-code */}
             <Grid item xs={12}>
-              <Typography variant="h6" gutterBottom>Automatic G-code</Typography>
-              <Typography variant="body2" color="text.secondary" gutterBottom>
-                Commands run automatically for this plotter. One command per line; empty lines are ignored.
+              <Typography variant="h6" gutterBottom>
+                Automatic G-code
               </Typography>
+              <Typography variant="body2" color="text.secondary" gutterBottom>
+                Commands run automatically for this plotter. One command per
+                line; empty lines are ignored.
+              </Typography>
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <TextField
+                fullWidth
+                label="Draw Speed (mm/min)"
+                type="number"
+                value={formData.gcode_draw_speed}
+                onChange={(e) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    gcode_draw_speed: parseFloat(e.target.value) || 0,
+                  }))
+                }
+                inputProps={{ min: 500, max: 8000, step: 50 }}
+                helperText="Applied as the G1 feed rate after pen down."
+              />
             </Grid>
             <Grid item xs={12} sm={6}>
               <TextField
@@ -530,7 +671,12 @@ export default function PlotterConfiguration() {
                 minRows={6}
                 label="On Connect"
                 value={formData.gcode_on_connect}
-                onChange={(e) => setFormData(prev => ({ ...prev, gcode_on_connect: e.target.value }))}
+                onChange={(e) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    gcode_on_connect: e.target.value,
+                  }))
+                }
                 placeholder="G21&#10;G90"
                 helperText="Sent immediately after connecting to the plotter."
               />
@@ -542,7 +688,12 @@ export default function PlotterConfiguration() {
                 minRows={6}
                 label="Before Print Start"
                 value={formData.gcode_before_print}
-                onChange={(e) => setFormData(prev => ({ ...prev, gcode_before_print: e.target.value }))}
+                onChange={(e) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    gcode_before_print: e.target.value,
+                  }))
+                }
                 placeholder="G92 X0 Y0 Z0"
                 helperText="Sent right before a print job begins."
               />
@@ -554,7 +705,12 @@ export default function PlotterConfiguration() {
                   control={
                     <Checkbox
                       checked={formData.is_default}
-                      onChange={(e) => setFormData(prev => ({ ...prev, is_default: e.target.checked }))}
+                      onChange={(e) =>
+                        setFormData((prev) => ({
+                          ...prev,
+                          is_default: e.target.checked,
+                        }))
+                      }
                     />
                   }
                   label="Set as default plotter"
@@ -569,12 +725,17 @@ export default function PlotterConfiguration() {
         <DialogActions>
           <Button onClick={() => setDialogOpen(false)}>Cancel</Button>
           <Button onClick={handleSave} variant="contained">
-            {editingPlotter ? 'Update' : 'Create'}
+            {editingPlotter ? "Update" : "Create"}
           </Button>
         </DialogActions>
       </Dialog>
 
-      <Dialog open={deleteDialogOpen} onClose={closeDeleteDialog} maxWidth="xs" fullWidth>
+      <Dialog
+        open={deleteDialogOpen}
+        onClose={closeDeleteDialog}
+        maxWidth="xs"
+        fullWidth
+      >
         <DialogTitle>Delete plotter?</DialogTitle>
         <DialogContent>
           <Typography variant="body2" color="text.secondary">
@@ -587,7 +748,12 @@ export default function PlotterConfiguration() {
           <Button onClick={closeDeleteDialog} disabled={deleting}>
             Cancel
           </Button>
-          <Button onClick={handleDelete} color="error" variant="contained" disabled={deleting}>
+          <Button
+            onClick={handleDelete}
+            color="error"
+            variant="contained"
+            disabled={deleting}
+          >
             {deleting ? "Deleting..." : "Delete"}
           </Button>
         </DialogActions>


### PR DESCRIPTION
## Summary
- add draw speed setting to plotter G-code configuration with validation and persistence
- apply draw speed in vpype output (single feed-rate set after pen down)
- expose draw speed controls in G-code settings and plotter edit UI

## Test plan
- [x] Update plotter draw_speed via API (curl)
- [x] Verify in UI by editing plotter draw speed and confirming it persists