### PR TITLE
Remove unused plotter settings and draw speed (#39)

### DIFF
--- a/backend/app/config_models.py
+++ b/backend/app/config_models.py
@@ -10,12 +10,6 @@ class GcodeSettings(BaseModel):
     before_print: List[str] = Field(default_factory=list, description="Commands to run just before starting a print job")
     pen_up_command: str = Field(default="M280 P0 S110", description="Command to raise pen")
     pen_down_command: str = Field(default="M280 P0 S130", description="Command to lower pen")
-    draw_speed: float = Field(
-        default=2000.0,
-        ge=500.0,
-        le=8000.0,
-        description="Drawing feed rate in mm/min used for G-code generation",
-    )
     servo_delay_ms: float = Field(default=100.0, description="Delay in milliseconds after servo commands to allow settling (reduces bouncing)")
 
 
@@ -25,20 +19,7 @@ class GcodeSettingsUpdate(BaseModel):
     before_print: Optional[List[str]] = Field(None, description="Commands to run before print start")
     pen_up_command: Optional[str] = Field(None, description="Command to raise pen")
     pen_down_command: Optional[str] = Field(None, description="Command to lower pen")
-    draw_speed: Optional[float] = Field(
-        None,
-        ge=500.0,
-        le=8000.0,
-        description="Drawing feed rate in mm/min used for G-code generation",
-    )
     servo_delay_ms: Optional[float] = Field(None, description="Delay in milliseconds after servo commands to allow settling")
-
-
-class PlotterType(str, Enum):
-    """Enum for different plotter types"""
-    POLARGRAPH = "polargraph"
-    XY_PLOTTER = "xy_plotter"
-    PEN_PLOTTER = "pen_plotter"
 
 
 class PaperSize(str, Enum):
@@ -64,19 +45,13 @@ class PaperSize(str, Enum):
 class PlotterSettings(BaseModel):
     """Settings for a specific plotter configuration"""
     name: str = Field(..., description="Name of the plotter configuration")
-    plotter_type: PlotterType = Field(..., description="Type of plotter")
     width: float = Field(..., description="Plotting area width in mm")
     height: float = Field(..., description="Plotting area height in mm")
     mm_per_rev: float = Field(..., description="Millimeters per motor revolution")
     steps_per_rev: float = Field(..., description="Steps per motor revolution")
     max_speed: float = Field(default=100.0, description="Maximum speed in mm/s")
-    acceleration: float = Field(default=50.0, description="Acceleration in mm/s²")
-    pen_up_position: float = Field(default=10.0, description="Pen up position in mm")
-    pen_down_position: float = Field(default=0.0, description="Pen down position in mm")
-    pen_speed: float = Field(default=20.0, description="Pen movement speed in mm/s")
+    pen_speed: float = Field(default=2000.0, description="Pen movement speed in mm/min")
     gcode_sequences: GcodeSettings = Field(default_factory=GcodeSettings, description="Automatic G-code for this plotter")
-    home_position_x: float = Field(default=0.0, description="Home position X coordinate")
-    home_position_y: float = Field(default=0.0, description="Home position Y coordinate")
     is_default: bool = Field(default=False, description="Whether this is the default plotter")
     created_at: datetime = Field(default_factory=datetime.now)
     updated_at: datetime = Field(default_factory=datetime.now)
@@ -97,42 +72,30 @@ class PaperSettings(BaseModel):
 class PlotterCreate(BaseModel):
     """Model for creating a new plotter configuration"""
     name: str = Field(..., description="Name of the plotter configuration")
-    plotter_type: PlotterType = Field(default=PlotterType.POLARGRAPH, description="Type of plotter")
     width: float = Field(default=1000.0, description="Plotting area width in mm")
     height: float = Field(default=1000.0, description="Plotting area height in mm")
     mm_per_rev: float = Field(default=95.0, description="Millimeters per motor revolution")
     steps_per_rev: float = Field(default=200.0, description="Steps per motor revolution")
     max_speed: float = Field(default=100.0, description="Maximum speed in mm/s")
-    acceleration: float = Field(default=50.0, description="Acceleration in mm/s²")
-    pen_up_position: float = Field(default=10.0, description="Pen up position in mm")
-    pen_down_position: float = Field(default=0.0, description="Pen down position in mm")
-    pen_speed: float = Field(default=20.0, description="Pen movement speed in mm/s")
+    pen_speed: float = Field(default=2000.0, description="Pen movement speed in mm/min")
     gcode_sequences: GcodeSettings = Field(default_factory=GcodeSettings, description="Automatic G-code for this plotter")
     gcode_pen_up_command: Optional[str] = Field(None, description="Command to raise pen (legacy)")
     gcode_pen_down_command: Optional[str] = Field(None, description="Command to lower pen (legacy)")
-    home_position_x: float = Field(default=0.0, description="Home position X coordinate")
-    home_position_y: float = Field(default=0.0, description="Home position Y coordinate")
     is_default: bool = Field(default=False, description="Whether this is the default plotter")
 
 
 class PlotterUpdate(BaseModel):
     """Model for updating a plotter configuration"""
     name: Optional[str] = Field(None, description="Name of the plotter configuration")
-    plotter_type: Optional[PlotterType] = Field(None, description="Type of plotter")
     width: Optional[float] = Field(None, description="Plotting area width in mm")
     height: Optional[float] = Field(None, description="Plotting area height in mm")
     mm_per_rev: Optional[float] = Field(None, description="Millimeters per motor revolution")
     steps_per_rev: Optional[float] = Field(None, description="Steps per motor revolution")
     max_speed: Optional[float] = Field(None, description="Maximum speed in mm/s")
-    acceleration: Optional[float] = Field(None, description="Acceleration in mm/s²")
-    pen_up_position: Optional[float] = Field(None, description="Pen up position in mm")
-    pen_down_position: Optional[float] = Field(None, description="Pen down position in mm")
-    pen_speed: Optional[float] = Field(None, description="Pen movement speed in mm/s")
+    pen_speed: Optional[float] = Field(None, description="Pen movement speed in mm/min")
     gcode_sequences: Optional[GcodeSettings] = Field(None, description="Automatic G-code for this plotter")
     gcode_pen_up_command: Optional[str] = Field(None, description="Command to raise pen (legacy)")
     gcode_pen_down_command: Optional[str] = Field(None, description="Command to lower pen (legacy)")
-    home_position_x: Optional[float] = Field(None, description="Home position X coordinate")
-    home_position_y: Optional[float] = Field(None, description="Home position Y coordinate")
     is_default: Optional[bool] = Field(None, description="Whether this is the default plotter")
 
 
@@ -160,19 +123,13 @@ class PlotterResponse(BaseModel):
     """Response model for plotter configuration"""
     id: str = Field(..., description="Unique identifier for the plotter")
     name: str = Field(..., description="Name of the plotter configuration")
-    plotter_type: PlotterType = Field(..., description="Type of plotter")
     width: float = Field(..., description="Plotting area width in mm")
     height: float = Field(..., description="Plotting area height in mm")
     mm_per_rev: float = Field(..., description="Millimeters per motor revolution")
     steps_per_rev: float = Field(..., description="Steps per motor revolution")
     max_speed: float = Field(..., description="Maximum speed in mm/s")
-    acceleration: float = Field(..., description="Acceleration in mm/s²")
-    pen_up_position: float = Field(..., description="Pen up position in mm")
-    pen_down_position: float = Field(..., description="Pen down position in mm")
-    pen_speed: float = Field(..., description="Pen movement speed in mm/s")
+    pen_speed: float = Field(..., description="Pen movement speed in mm/min")
     gcode_sequences: GcodeSettings = Field(..., description="Automatic G-code for this plotter")
-    home_position_x: float = Field(..., description="Home position X coordinate")
-    home_position_y: float = Field(..., description="Home position Y coordinate")
     is_default: bool = Field(..., description="Whether this is the default plotter")
     created_at: datetime = Field(..., description="Creation timestamp")
     updated_at: datetime = Field(..., description="Last update timestamp")

--- a/backend/app/config_service.py
+++ b/backend/app/config_service.py
@@ -186,19 +186,13 @@ class ConfigurationService:
             {
                 "id": str(uuid.uuid4()),
                 "name": "Default Polargraph",
-                "plotter_type": "polargraph",
                 "width": 1000.0,
                 "height": 1000.0,
                 "mm_per_rev": 95.0,
                 "steps_per_rev": 200.0,
                 "max_speed": 100.0,
-            "acceleration": 50.0,
-            "pen_up_position": 10.0,
-            "pen_down_position": 0.0,
-            "pen_speed": 20.0,
-            "gcode_sequences": self._get_default_gcode_sequences(),
-                "home_position_x": 0.0,
-                "home_position_y": 0.0,
+                "pen_speed": 2000.0,
+                "gcode_sequences": self._get_default_gcode_sequences(),
                 "is_default": True,
                 "created_at": datetime.now().isoformat(),
                 "updated_at": datetime.now().isoformat()
@@ -368,18 +362,8 @@ class ConfigurationService:
             ],
             "pen_up_command": "M280 P0 S110",
             "pen_down_command": "M280 P0 S130",
-            "draw_speed": 2000.0,
             "servo_delay_ms": 100.0,
         }
-
-    @staticmethod
-    def _normalize_draw_speed(value: Optional[float]) -> float:
-        """Clamp draw speed to a safe range (mm/min)."""
-        try:
-            speed = float(value)
-        except (TypeError, ValueError):
-            return 2000.0
-        return min(max(speed, 500.0), 8000.0)
     
     def _validate_and_repair_config(self):
         """Validate and repair configuration to ensure all required fields exist"""
@@ -426,8 +410,8 @@ class ConfigurationService:
         # Ensure all plotters have required fields
         for plotter in self.config_data.get('plotters', []):
             required_fields = [
-                'id', 'name', 'plotter_type', 'width', 'height',
-                'mm_per_rev', 'steps_per_rev', 'gcode_sequences'
+                'id', 'name', 'width', 'height',
+                'mm_per_rev', 'steps_per_rev', 'pen_speed', 'gcode_sequences'
             ]
             for field in required_fields:
                 if field not in plotter:
@@ -435,20 +419,20 @@ class ConfigurationService:
                         plotter[field] = str(uuid.uuid4())
                     elif field in ['width', 'height', 'mm_per_rev', 'steps_per_rev']:
                         plotter[field] = 0.0
+                    elif field == 'pen_speed':
+                        plotter[field] = 2000.0
                     elif field == 'gcode_sequences':
                         plotter[field] = self._get_default_gcode_sequences()
-                    elif field == 'plotter_type':
-                        plotter[field] = 'polargraph'
                     else:
                         plotter[field] = 'Unknown'
                     needs_repair = True
 
             gcode_sequences = plotter.get('gcode_sequences', {})
-            if 'draw_speed' not in gcode_sequences:
-                gcode_sequences['draw_speed'] = 2000.0
+            if 'draw_speed' in gcode_sequences:
+                gcode_sequences.pop('draw_speed', None)
                 plotter['gcode_sequences'] = gcode_sequences
                 needs_repair = True
-        
+
         # Ensure all papers have required fields
         for paper in self.config_data.get('papers', []):
             required_fields = ['id', 'name', 'paper_size', 'width', 'height', 'color']
@@ -504,19 +488,13 @@ class ConfigurationService:
         plotter_dict = {
             "id": plotter_id,
             "name": plotter_data.name,
-            "plotter_type": plotter_data.plotter_type.value,
             "width": plotter_data.width,
             "height": plotter_data.height,
             "mm_per_rev": plotter_data.mm_per_rev,
             "steps_per_rev": plotter_data.steps_per_rev,
             "max_speed": plotter_data.max_speed,
-            "acceleration": plotter_data.acceleration,
-            "pen_up_position": plotter_data.pen_up_position,
-            "pen_down_position": plotter_data.pen_down_position,
             "pen_speed": plotter_data.pen_speed,
             "gcode_sequences": gcode_sequences,
-            "home_position_x": plotter_data.home_position_x,
-            "home_position_y": plotter_data.home_position_y,
             "is_default": plotter_data.is_default,
             "created_at": now.isoformat(),
             "updated_at": now.isoformat()
@@ -575,9 +553,7 @@ class ConfigurationService:
                         existing_sequences['pen_down_command'] = pen_down_override
                     update_data['gcode_sequences'] = existing_sequences
                 for key, value in update_data.items():
-                    if key == 'plotter_type':
-                        plotter[key] = value.value
-                    elif key == 'gcode_sequences' and value is not None:
+                    if key == 'gcode_sequences' and value is not None:
                         if isinstance(value, dict):
                             plotter[key] = value
                         else:
@@ -714,7 +690,6 @@ class ConfigurationService:
             before_print=defaults.get("before_print", []),
             pen_up_command=defaults.get("pen_up_command", "M280 P0 S110"),
             pen_down_command=defaults.get("pen_down_command", "M280 P0 S130"),
-            draw_speed=self._normalize_draw_speed(defaults.get("draw_speed", 2000.0)),
             servo_delay_ms=defaults.get("servo_delay_ms", 100.0),
         )
 
@@ -757,26 +732,19 @@ class ConfigurationService:
         return PlotterResponse(
             id=plotter_dict['id'],
             name=plotter_dict['name'],
-            plotter_type=plotter_dict['plotter_type'],
             width=plotter_dict['width'],
             height=plotter_dict['height'],
             mm_per_rev=plotter_dict['mm_per_rev'],
             steps_per_rev=plotter_dict['steps_per_rev'],
             max_speed=plotter_dict['max_speed'],
-            acceleration=plotter_dict['acceleration'],
-            pen_up_position=plotter_dict['pen_up_position'],
-            pen_down_position=plotter_dict['pen_down_position'],
             pen_speed=plotter_dict['pen_speed'],
             gcode_sequences=GcodeSettings(
                 on_connect=gcode_data.get('on_connect', []),
                 before_print=gcode_data.get('before_print', []),
                 pen_up_command=gcode_data.get('pen_up_command', "M280 P0 S110"),
                 pen_down_command=gcode_data.get('pen_down_command', "M280 P0 S130"),
-                draw_speed=self._normalize_draw_speed(gcode_data.get('draw_speed', 2000.0)),
                 servo_delay_ms=gcode_data.get('servo_delay_ms', 100.0),
             ),
-            home_position_x=plotter_dict['home_position_x'],
-            home_position_y=plotter_dict['home_position_y'],
             is_default=plotter_dict['is_default'],
             created_at=datetime.fromisoformat(plotter_dict['created_at']),
             updated_at=datetime.fromisoformat(plotter_dict['updated_at'])
@@ -814,7 +782,6 @@ class ConfigurationService:
                     before_print=gcode_data.get('before_print', []),
                     pen_up_command=pen_up,
                     pen_down_command=pen_down,
-                    draw_speed=self._normalize_draw_speed(gcode_data.get('draw_speed', 2000.0)),
                     servo_delay_ms=gcode_data.get('servo_delay_ms', 100.0),
                 )
         return None
@@ -838,9 +805,6 @@ class ConfigurationService:
                 if 'pen_down_command' in update_payload:
                     if update_payload['pen_down_command'] is not None:
                         existing['pen_down_command'] = update_payload['pen_down_command']
-                if 'draw_speed' in update_payload:
-                    if update_payload['draw_speed'] is not None:
-                        existing['draw_speed'] = self._normalize_draw_speed(update_payload['draw_speed'])
                 if 'servo_delay_ms' in update_payload:
                     if update_payload['servo_delay_ms'] is not None:
                         existing['servo_delay_ms'] = update_payload['servo_delay_ms']

--- a/backend/app/gcode_analyzer.py
+++ b/backend/app/gcode_analyzer.py
@@ -69,10 +69,10 @@ def analyze_gcode_file(
     default_travel_feed = travel_feed_mm_per_min
 
     if default_plotter:
-        default_draw_feed = default_draw_feed or (default_plotter.pen_speed * 60.0)
+        default_draw_feed = default_draw_feed or default_plotter.pen_speed
         default_travel_feed = default_travel_feed or (default_plotter.max_speed * 60.0)
 
-    default_draw_feed = default_draw_feed or 1200.0  # reasonable pen speed (~20 mm/s)
+    default_draw_feed = default_draw_feed or 2000.0  # reasonable pen speed (mm/min)
     default_travel_feed = default_travel_feed or 6000.0  # faster travel (~100 mm/s)
 
     current_draw_feed = default_draw_feed

--- a/backend/app/vpype_converter.py
+++ b/backend/app/vpype_converter.py
@@ -460,20 +460,27 @@ def build_vpype_config_content(
 ) -> str:
     """Generate vpype config content using current plotter gcode settings."""
     gcode = _get_default_gcode_settings()
+    plotter = None
+    try:
+        from .config_service import config_service
+
+        plotter = config_service.get_default_plotter()
+    except Exception:
+        plotter = None
     pen_up = getattr(gcode, "pen_up_command", "M280 P0 S110")
     if pen_up is None:
         pen_up = "M280 P0 S110"
     pen_down = getattr(gcode, "pen_down_command", "M280 P0 S130")
     if pen_down is None:
         pen_down = "M280 P0 S130"
-    draw_speed = getattr(gcode, "draw_speed", None)
-    if draw_speed is None:
-        draw_speed = 2000.0
+    pen_speed = getattr(plotter, "pen_speed", None)
+    if pen_speed is None:
+        pen_speed = 2000.0
     try:
-        draw_speed = float(draw_speed)
+        pen_speed = float(pen_speed)
     except (TypeError, ValueError):
-        draw_speed = 2000.0
-    draw_speed = min(max(draw_speed, 500.0), 8000.0)
+        pen_speed = 2000.0
+    draw_speed = min(max(pen_speed, 500.0), 8000.0)
     draw_feed = f"{draw_speed:g}"
     if servo_delay_ms is None:
         servo_delay_ms = 100.0

--- a/frontend/src/components/GcodeSettings.jsx
+++ b/frontend/src/components/GcodeSettings.jsx
@@ -26,11 +26,9 @@ export default function GcodeSettings() {
   const [settings, setSettings] = useState({
     on_connect: [],
     before_print: [],
-    draw_speed: 2000,
   });
   const [onConnectText, setOnConnectText] = useState("");
   const [beforePrintText, setBeforePrintText] = useState("");
-  const [drawSpeed, setDrawSpeed] = useState("2000");
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(null);
   const [runningPrePrint, setRunningPrePrint] = useState(false);
@@ -59,29 +57,11 @@ export default function GcodeSettings() {
       setSettings(result);
       setOnConnectText(toMultiline(result.on_connect));
       setBeforePrintText(toMultiline(result.before_print));
-      setDrawSpeed(
-        result.draw_speed !== undefined && result.draw_speed !== null
-          ? String(result.draw_speed)
-          : "2000",
-      );
     } catch (err) {
       setError(err.message);
     } finally {
       setLoading(false);
     }
-  };
-
-  const parseDrawSpeed = () => {
-    const value = Number(drawSpeed);
-    if (Number.isNaN(value)) {
-      setError("Draw speed must be a number.");
-      return null;
-    }
-    if (value < 500 || value > 8000) {
-      setError("Draw speed must be between 500 and 8000 mm/min.");
-      return null;
-    }
-    return value;
   };
 
   const handleSave = async () => {
@@ -90,15 +70,9 @@ export default function GcodeSettings() {
       setSuccess(null);
       setError(null);
 
-      const speedValue = parseDrawSpeed();
-      if (speedValue === null) {
-        return;
-      }
-
       const payload = {
         on_connect: normalizeCommands(onConnectText),
         before_print: normalizeCommands(beforePrintText),
-        draw_speed: speedValue,
       };
 
       const updated = await updateGcodeSettings(payload);
@@ -168,17 +142,6 @@ export default function GcodeSettings() {
         )}
 
         <Grid container spacing={3}>
-          <Grid item xs={12}>
-            <TextField
-              label="Draw Speed (mm/min)"
-              type="number"
-              fullWidth
-              value={drawSpeed}
-              onChange={(e) => setDrawSpeed(e.target.value)}
-              helperText="Used for generated G-code drawing moves (500-8000)."
-              inputProps={{ min: 500, max: 8000, step: 50 }}
-            />
-          </Grid>
           <Grid item xs={12} md={6}>
             <TextField
               label="On Connect"

--- a/frontend/src/components/PlotterConfiguration.jsx
+++ b/frontend/src/components/PlotterConfiguration.jsx
@@ -22,10 +22,7 @@ import {
   FormHelperText,
   Grid,
   IconButton,
-  InputLabel,
-  MenuItem,
   Paper,
-  Select,
   Snackbar,
   Table,
   TableBody,
@@ -44,12 +41,6 @@ import {
   updatePlotter,
 } from "../services/apiService";
 
-const PLOTTER_TYPES = [
-  { value: "polargraph", label: "Polargraph" },
-  { value: "xy_plotter", label: "XY Plotter" },
-  { value: "pen_plotter", label: "Pen Plotter" },
-];
-
 export default function PlotterConfiguration() {
   const [plotters, setPlotters] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -62,19 +53,14 @@ export default function PlotterConfiguration() {
   const [deleting, setDeleting] = useState(false);
   const [formData, setFormData] = useState({
     name: "",
-    plotter_type: "polargraph",
     width: 1000,
     height: 1000,
     mm_per_rev: 95.0,
     steps_per_rev: 200.0,
     max_speed: 100.0,
-    acceleration: 50.0,
-    pen_up_position: 10.0,
-    pen_down_position: 0.0,
-    pen_speed: 20.0,
+    pen_speed: 2000.0,
     gcode_pen_up_command: "M280 P0 S110",
     gcode_pen_down_command: "M280 P0 S130",
-    gcode_draw_speed: 2000,
     gcode_on_connect: "",
     gcode_before_print: "",
     home_position_x: 0.0,
@@ -110,19 +96,14 @@ export default function PlotterConfiguration() {
     setEditingPlotter(null);
     setFormData({
       name: "",
-      plotter_type: "polargraph",
       width: 1000,
       height: 1000,
       mm_per_rev: 95.0,
       steps_per_rev: 200.0,
       max_speed: 100.0,
-      acceleration: 50.0,
-      pen_up_position: 10.0,
-      pen_down_position: 0.0,
-      pen_speed: 20.0,
+      pen_speed: 2000.0,
       gcode_pen_up_command: "M280 P0 S110",
       gcode_pen_down_command: "M280 P0 S130",
-      gcode_draw_speed: 2000,
       gcode_on_connect: "",
       gcode_before_print: "",
       home_position_x: 0.0,
@@ -136,21 +117,16 @@ export default function PlotterConfiguration() {
     setEditingPlotter(plotter);
     setFormData({
       name: plotter.name,
-      plotter_type: plotter.plotter_type,
       width: plotter.width,
       height: plotter.height,
       mm_per_rev: plotter.mm_per_rev,
       steps_per_rev: plotter.steps_per_rev,
       max_speed: plotter.max_speed,
-      acceleration: plotter.acceleration,
-      pen_up_position: plotter.pen_up_position,
-      pen_down_position: plotter.pen_down_position,
       pen_speed: plotter.pen_speed,
       gcode_pen_up_command:
         plotter.gcode_sequences?.pen_up_command || "M280 P0 S110",
       gcode_pen_down_command:
         plotter.gcode_sequences?.pen_down_command || "M280 P0 S130",
-      gcode_draw_speed: plotter.gcode_sequences?.draw_speed ?? 2000,
       gcode_on_connect: (plotter.gcode_sequences?.on_connect || []).join("\n"),
       gcode_before_print: (plotter.gcode_sequences?.before_print || []).join(
         "\n",
@@ -177,9 +153,6 @@ export default function PlotterConfiguration() {
             .filter(Boolean),
           pen_up_command: formData.gcode_pen_up_command || "M280 P0 S110",
           pen_down_command: formData.gcode_pen_down_command || "M280 P0 S130",
-          draw_speed: Number.isFinite(formData.gcode_draw_speed)
-            ? formData.gcode_draw_speed
-            : 2000,
         },
       };
       if (editingPlotter) {
@@ -273,7 +246,6 @@ export default function PlotterConfiguration() {
           <TableHead>
             <TableRow>
               <TableCell>Name</TableCell>
-              <TableCell>Type</TableCell>
               <TableCell>Dimensions (mm)</TableCell>
               <TableCell>Motor Settings</TableCell>
               <TableCell>Default</TableCell>
@@ -284,9 +256,6 @@ export default function PlotterConfiguration() {
             {plotters.map((plotter) => (
               <TableRow key={plotter.id}>
                 <TableCell>{plotter.name}</TableCell>
-                <TableCell>
-                  <Chip label={plotter.plotter_type} size="small" />
-                </TableCell>
                 <TableCell>
                   {plotter.width} × {plotter.height}
                 </TableCell>
@@ -362,27 +331,6 @@ export default function PlotterConfiguration() {
                 }
                 required
               />
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <FormControl fullWidth>
-                <InputLabel>Plotter Type</InputLabel>
-                <Select
-                  value={formData.plotter_type}
-                  onChange={(e) =>
-                    setFormData((prev) => ({
-                      ...prev,
-                      plotter_type: e.target.value,
-                    }))
-                  }
-                  label="Plotter Type"
-                >
-                  {PLOTTER_TYPES.map((type) => (
-                    <MenuItem key={type.value} value={type.value}>
-                      {type.label}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
             </Grid>
 
             <Grid item xs={12}>
@@ -492,21 +440,6 @@ export default function PlotterConfiguration() {
                 required
               />
             </Grid>
-            <Grid item xs={12} sm={6}>
-              <TextField
-                fullWidth
-                label="Acceleration (mm/s²)"
-                type="number"
-                value={formData.acceleration}
-                onChange={(e) =>
-                  setFormData((prev) => ({
-                    ...prev,
-                    acceleration: parseFloat(e.target.value) || 0,
-                  }))
-                }
-                required
-              />
-            </Grid>
 
             <Grid item xs={12}>
               <Divider sx={{ my: 2 }} />
@@ -518,40 +451,10 @@ export default function PlotterConfiguration() {
                 Pen Settings
               </Typography>
             </Grid>
-            <Grid item xs={12} sm={4}>
+            <Grid item xs={12} sm={6}>
               <TextField
                 fullWidth
-                label="Pen Up Position (mm)"
-                type="number"
-                value={formData.pen_up_position}
-                onChange={(e) =>
-                  setFormData((prev) => ({
-                    ...prev,
-                    pen_up_position: parseFloat(e.target.value) || 0,
-                  }))
-                }
-                required
-              />
-            </Grid>
-            <Grid item xs={12} sm={4}>
-              <TextField
-                fullWidth
-                label="Pen Down Position (mm)"
-                type="number"
-                value={formData.pen_down_position}
-                onChange={(e) =>
-                  setFormData((prev) => ({
-                    ...prev,
-                    pen_down_position: parseFloat(e.target.value) || 0,
-                  }))
-                }
-                required
-              />
-            </Grid>
-            <Grid item xs={12} sm={4}>
-              <TextField
-                fullWidth
-                label="Pen Speed (mm/s)"
+                label="Pen Speed (mm/min)"
                 type="number"
                 value={formData.pen_speed}
                 onChange={(e) =>
@@ -647,22 +550,6 @@ export default function PlotterConfiguration() {
                 Commands run automatically for this plotter. One command per
                 line; empty lines are ignored.
               </Typography>
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <TextField
-                fullWidth
-                label="Draw Speed (mm/min)"
-                type="number"
-                value={formData.gcode_draw_speed}
-                onChange={(e) =>
-                  setFormData((prev) => ({
-                    ...prev,
-                    gcode_draw_speed: parseFloat(e.target.value) || 0,
-                  }))
-                }
-                inputProps={{ min: 500, max: 8000, step: 50 }}
-                helperText="Applied as the G1 feed rate after pen down."
-              />
             </Grid>
             <Grid item xs={12} sm={6}>
               <TextField


### PR DESCRIPTION
## Summary
- remove unused plotter configuration fields from backend models/service and frontend UI
- drop draw_speed in favor of pen_speed for G-code feedrate generation
- update defaults and config repair logic to keep plotter settings consistent

## Test plan
- not run