### PR TITLE
Print Gcode: rename Stop to Abort, add Stop (streaming only)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1363,6 +1363,11 @@ async def stop_plotter():
     """Stop plotter immediately and cancel any running G-code jobs."""
     return await plotter_service.stop_plotter()
 
+@app.post("/plotter/gcode/stop")
+async def stop_gcode_streaming():
+    """Stop streaming G-code without emergency stop."""
+    return await plotter_service.stop_gcode_streaming()
+
 
 @app.post("/plotter/pause")
 async def pause_plotter():

--- a/backend/app/plotter_service.py
+++ b/backend/app/plotter_service.py
@@ -455,6 +455,29 @@ class PlotterService:
                         job["finished_at"] = datetime.now().isoformat()
         self.gcode_pause_all.clear()
 
+    async def stop_gcode_streaming(self) -> Dict[str, Any]:
+        """Stop streaming G-code without sending an emergency stop."""
+        try:
+            self.cancel_all_gcode_jobs()
+            self.current_status["drawing"] = False
+            self.current_status["current_command"] = None
+
+            with self._gcode_jobs_lock:
+                canceled_jobs = [
+                    job_id
+                    for job_id, job in self.gcode_jobs.items()
+                    if job.get("status") == "canceled"
+                ]
+
+            return {
+                "success": True,
+                "message": "G-code streaming stopped",
+                "canceled_jobs": canceled_jobs,
+            }
+        except Exception as exc:
+            logger.error("Stop G-code streaming error: %s", exc)
+            return {"success": False, "error": str(exc)}
+
     async def stop_plotter(self) -> Dict[str, Any]:
         """Stop plotter immediately and cancel any running G-code jobs."""
         try:

--- a/frontend/src/components/ControlPanel.jsx
+++ b/frontend/src/components/ControlPanel.jsx
@@ -48,6 +48,7 @@ import {
   resolveWsBaseUrl,
   runProjectGcode,
   sendGcodeCommand,
+  stopGcodeStreaming,
   stopPlotter,
   togglePausePlotter,
 } from "../services/apiService";
@@ -899,6 +900,23 @@ export default function ControlPanel({ currentProject }) {
     });
   };
 
+  const handleStopGcodeStreaming = () => {
+    stopProgressPolling();
+    setGcodeRunning(false);
+    setGcodePaused(false);
+    setGcodeProgress({
+      jobId: null,
+      linesSent: 0,
+      linesTotal: 0,
+      progress: 0,
+      status: null,
+    });
+    localStorage.removeItem("pv_gcode_progress");
+    stopGcodeStreaming().catch((err) =>
+      showSnackbar(`Stop streaming error: ${err.message}`, "error")
+    );
+  };
+
   const handleHomeAxis = (axis) => {
     sendCommand(`G28 ${axis.toUpperCase()}`);
   };
@@ -1088,14 +1106,15 @@ export default function ControlPanel({ currentProject }) {
                         </Button>
                         <Chip
                           icon={<Stop />}
-                          label="Stop"
+                          label="Abort"
                           color="error"
                           variant="outlined"
                           clickable
-                          disabled={!connected}
+                          disabled={!connected || !gcodeRunning}
                           onClick={() => {
                             stopProgressPolling();
                             setGcodeRunning(false);
+                            setGcodePaused(false);
                             setGcodeProgress({
                               jobId: null,
                               linesSent: 0,
@@ -1108,6 +1127,16 @@ export default function ControlPanel({ currentProject }) {
                               showSnackbar(`Stop error: ${err.message}`, "error")
                             );
                           }}
+                          sx={{ fontWeight: "bold", textTransform: "none" }}
+                        />
+                        <Chip
+                          icon={<Stop />}
+                          label="Stop"
+                          color="warning"
+                          variant="outlined"
+                          clickable
+                          disabled={!connected || !gcodeRunning}
+                          onClick={handleStopGcodeStreaming}
                           sx={{ fontWeight: "bold", textTransform: "none" }}
                         />
                         <Chip

--- a/frontend/src/services/apiService.js
+++ b/frontend/src/services/apiService.js
@@ -840,6 +840,24 @@ export async function stopPlotter() {
   }
 }
 
+export async function stopGcodeStreaming() {
+  try {
+    const response = await fetch(`${BASE_URL}/plotter/gcode/stop`, {
+      method: "POST",
+    });
+    const data = await response.json();
+    if (!response.ok || data.success === false) {
+      throw new Error(
+        data.error || data.detail || "Failed to stop G-code streaming"
+      );
+    }
+    return data;
+  } catch (err) {
+    console.error("Error stopping G-code streaming:", err);
+    throw err;
+  }
+}
+
 export async function sendGcodeCommand(gcode) {
   try {
     const response = await fetch(`${BASE_URL}/plotter/gcode`, {


### PR DESCRIPTION
Closes #42

## Summary
- Rename existing **Stop** in Print Gcode panel to **Abort** (unchanged behavior: full stop + emergency M112).
- Add new **Stop** control that only stops G-code streaming (no M112; machine stays in current state).

## Demo/Test plan
- Start a print (or simulator). Click **Stop** → streaming halts, no abort. Click **Abort** → full stop/M112 behavior.
- When no print is active, both Abort and Stop are disabled.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive change that introduces a new endpoint and UI control for an alternate stop path; risk is limited to job-cancellation/state-reset behavior during active prints.
> 
> **Overview**
> Adds a new backend endpoint `POST /plotter/gcode/stop` and `PlotterService.stop_gcode_streaming()` to cancel active/queued G-code jobs and clear “drawing/current_command” *without* sending `M112`.
> 
> Updates the Print Gcode UI to rename the existing Stop action to **Abort** (still calls `stopPlotter()` / emergency stop behavior) and introduces a new **Stop** button that calls `stopGcodeStreaming()` and resets local progress/polling state; the new client API wrapper is added in `apiService.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 838d9ea0676e3cf1a16a6bfdd4af40aa3f412333. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->