### PR TITLE
Print Gcode: rename Stop to Abort, add Stop (streaming only)

### DIFF
--- a/frontend/src/components/ControlPanel.jsx
+++ b/frontend/src/components/ControlPanel.jsx
@@ -4,7 +4,6 @@ import {
   ArrowForward,
   ArrowUpward,
   Clear,
-  Home,
   Refresh,
   Send,
   Stop,
@@ -861,10 +860,6 @@ export default function ControlPanel({ currentProject }) {
     }
   };
 
-  const handleHome = () => {
-    sendCommand("G28");
-  };
-
   const handleMove = async (x, y) => {
     if (!connected) {
       showSnackbar("Please connect to plotter first", "warning");
@@ -892,12 +887,6 @@ export default function ControlPanel({ currentProject }) {
     } catch {
       setPenState(prev);
     }
-  };
-
-  const handleStop = () => {
-    stopPlotter().catch((err) => {
-      showSnackbar(`Stop error: ${err.message}`, "error");
-    });
   };
 
   const handleStopGcodeStreaming = () => {
@@ -1533,35 +1522,6 @@ export default function ControlPanel({ currentProject }) {
                     alignItems: "center",
                   }}
                 >
-                  <Chip
-                    label="Stop"
-                    color="error"
-                    variant="filled"
-                    icon={<Stop />}
-                    clickable={connected}
-                    onClick={handleStop}
-                    sx={{
-                      minWidth: 110,
-                      textTransform: "none",
-                      fontWeight: "bold",
-                    }}
-                  />
-                  <Chip
-                    label="Auto Home"
-                    color="primary"
-                    variant="filled"
-                    icon={<Home />}
-                    clickable={connected}
-                    onClick={() => {
-                      if (!connected) return;
-                      handleHome();
-                    }}
-                    sx={{
-                      minWidth: 110,
-                      textTransform: "none",
-                      fontWeight: "bold",
-                    }}
-                  />
                   <Chip
                     label="Set Home"
                     color="primary"


### PR DESCRIPTION
Closes #42

## Summary
- Rename existing **Stop** in Print Gcode panel to **Abort** (full stop + emergency M112).
- Add new **Stop** control that only stops G-code streaming (no M112).
- Remove Stop and Auto Home chips from Movement Controls (redundant / cleanup).

## Demo/Test plan
- Start a print. Click **Stop** → streaming halts. Click **Abort** → full stop/M112.
- Movement Controls: only Set Home, Relative/Absolute, Pen Up/Down (no Stop, no Auto Home).

Made with [Cursor](https://cursor.com)