### PR TITLE
fix: recover from ok timeout deadlock and send M108 on resume

### DIFF
--- a/backend/app/plotter_core.py
+++ b/backend/app/plotter_core.py
@@ -375,6 +375,7 @@ class PlotterCore:
                     time.sleep(0.001)
                 if not self.clear:
                     logger.warning(f"Timeout waiting for 'ok' after command: {command}")
+                    self.clear = True  # Recover from deadlock so send loop can continue
         except DeviceError as e:
             msg = f"Can't write to plotter (disconnected?) {e}"
             logger.error(msg)

--- a/backend/app/plotter_service.py
+++ b/backend/app/plotter_service.py
@@ -527,7 +527,11 @@ class PlotterService:
             # Use PlotterCore if available
             if self.plotter_core and self.plotter_core.online:
                 if was_paused:
-                    # Resume
+                    # Resume: send M108 to unpause Marlin (stops "paused for user" wait)
+                    try:
+                        self.plotter_core.send_now("M108")
+                    except Exception as exc:
+                        logger.warning("Failed to send M108 resume command via PlotterCore: %s", exc)
                     if self.plotter_core.paused:
                         self.plotter_core.resume()
                     self.gcode_pause_all.clear()
@@ -560,6 +564,11 @@ class PlotterService:
             
             # Fallback to old method
             if was_paused:
+                if self.arduino and getattr(self.arduino, "is_open", False):
+                    try:
+                        self.arduino.write(b"M108\n")
+                    except Exception as exc:
+                        logger.warning("Failed to send M108 resume command: %s", exc)
                 self.gcode_pause_all.clear()
                 with self._gcode_jobs_lock:
                     for job in self.gcode_jobs.values():


### PR DESCRIPTION
## Summary
Fixes plotting stops that required manual pause/resume to recover.

## Changes
- **Timeout deadlock fix**: When the printer doesn't send `ok` within 5 seconds, set `clear=True` in PlotterCore so the send loop continues instead of hanging indefinitely.
- **M108 on resume**: Send M108 to Marlin when resuming so the printer unpauses programmatically without requiring the physical button.

## Test plan
1. Start a plot and let it run.
2. If plotting stops (e.g. due to USB/serial glitch), it should auto-recover and continue.
3. Pause via UI, then resume via UI — should resume without pressing printer button.

Made with [Cursor](https://cursor.com)