### PR TITLE
Adopt Scrible G-code to SVG conversion for preview

### DIFF
--- a/backend/app/gcode_svg.py
+++ b/backend/app/gcode_svg.py
@@ -1,0 +1,249 @@
+"""Convert G-code into SVG previews. Adapted from Scrible."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+import re
+from typing import Dict, List, Tuple
+
+
+Point = Tuple[float, float]
+_WORD_RE = re.compile(r"([A-Za-z])\s*([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)")
+
+
+@dataclass
+class _Move:
+    kind: str  # "draw" or "travel"
+    points: List[Point]
+
+
+def _strip_comment(line: str) -> str:
+    return line.split(";", 1)[0].strip()
+
+
+def _parse_words(line: str) -> Dict[str, float]:
+    words: Dict[str, float] = {}
+    for letter, number in _WORD_RE.findall(line):
+        words[letter.upper()] = float(number)
+    return words
+
+
+def _format_num(value: float) -> str:
+    return f"{value:.3f}"
+
+
+def _arc_polyline(
+    start: Point,
+    end: Point,
+    center: Point,
+    cw: bool,
+) -> List[Point]:
+    sx, sy = start
+    ex, ey = end
+    cx, cy = center
+    r_start = math.hypot(sx - cx, sy - cy)
+    r_end = math.hypot(ex - cx, ey - cy)
+    radius = max(1e-9, 0.5 * (r_start + r_end))
+    start_ang = math.atan2(sy - cy, sx - cx)
+    end_ang = math.atan2(ey - cy, ex - cx)
+
+    if cw:
+        while end_ang >= start_ang:
+            end_ang -= 2.0 * math.pi
+        sweep = start_ang - end_ang
+        direction = -1.0
+    else:
+        while end_ang <= start_ang:
+            end_ang += 2.0 * math.pi
+        sweep = end_ang - start_ang
+        direction = 1.0
+
+    if sweep < 1e-6:
+        return [start, end]
+
+    # Approximate every 5 degrees max for visibly smooth arcs.
+    steps = max(8, min(720, int(math.ceil(sweep / (math.pi / 36.0)))))
+    pts: List[Point] = []
+    for i in range(steps + 1):
+        t = i / float(steps)
+        ang = start_ang + direction * sweep * t
+        pts.append((cx + radius * math.cos(ang), cy + radius * math.sin(ang)))
+    pts[-1] = end
+    return pts
+
+
+def _parse_moves(gcode_text: str) -> List[_Move]:
+    x = 0.0
+    y = 0.0
+    absolute_mode = True
+    pen_is_down = False
+    pen_up_servo: float | None = None
+    pen_down_servo: float | None = None
+    moves: List[_Move] = []
+
+    for raw_line in gcode_text.splitlines():
+        line = _strip_comment(raw_line)
+        if not line:
+            continue
+        words = _parse_words(line)
+        if "G" in words:
+            gnum = int(round(words["G"]))
+            cmd = f"G{gnum}"
+        elif "M" in words:
+            mnum = int(round(words["M"]))
+            cmd = f"M{mnum}"
+        else:
+            continue
+
+        if cmd == "G90":
+            absolute_mode = True
+            continue
+        if cmd == "G91":
+            absolute_mode = False
+            continue
+
+        if cmd == "M280" and "S" in words:
+            servo = words["S"]
+            if pen_up_servo is None:
+                pen_up_servo = servo
+                pen_is_down = False
+                continue
+            if pen_down_servo is None and not math.isclose(servo, pen_up_servo):
+                pen_down_servo = servo
+                pen_is_down = True
+                continue
+            if pen_down_servo is not None and math.isclose(servo, pen_down_servo):
+                pen_is_down = True
+                continue
+            if pen_up_servo is not None and math.isclose(servo, pen_up_servo):
+                pen_is_down = False
+                continue
+
+        if cmd not in {"G0", "G1", "G2", "G3"}:
+            continue
+
+        prev = (x, y)
+        if absolute_mode:
+            nx = words.get("X", x)
+            ny = words.get("Y", y)
+        else:
+            nx = x + words.get("X", 0.0)
+            ny = y + words.get("Y", 0.0)
+        nxt = (nx, ny)
+
+        if cmd in {"G0", "G1"}:
+            if not (math.isclose(prev[0], nxt[0]) and math.isclose(prev[1], nxt[1])):
+                kind = "travel" if (cmd == "G0" or not pen_is_down) else "draw"
+                moves.append(_Move(kind=kind, points=[prev, nxt]))
+            x, y = nx, ny
+            continue
+
+        # G2/G3 arcs with I/J center offsets from start point.
+        if "I" not in words or "J" not in words:
+            if not (math.isclose(prev[0], nxt[0]) and math.isclose(prev[1], nxt[1])):
+                kind = "draw" if pen_is_down else "travel"
+                moves.append(_Move(kind=kind, points=[prev, nxt]))
+            x, y = nx, ny
+            continue
+
+        center = (prev[0] + words["I"], prev[1] + words["J"])
+        arc_pts = _arc_polyline(prev, nxt, center, cw=(cmd == "G2"))
+        kind = "draw" if pen_is_down else "travel"
+        moves.append(_Move(kind=kind, points=arc_pts))
+        x, y = nx, ny
+
+    return moves
+
+
+def _to_svg_path(
+    points: List[Point],
+    *,
+    min_x: float,
+    min_y: float,
+    margin: float,
+) -> str:
+    if not points:
+        return ""
+    x0 = points[0][0] - min_x + margin
+    y0 = (-points[0][1]) - min_y + margin
+    out = [f"M {_format_num(x0)} {_format_num(y0)}"]
+    for x, y in points[1:]:
+        sx = x - min_x + margin
+        sy = (-y) - min_y + margin
+        out.append(f"L {_format_num(sx)} {_format_num(sy)}")
+    return " ".join(out)
+
+
+def gcode_to_svg_string(
+    gcode_text: str,
+    *,
+    draw_stroke_width_mm: float = 0.35,
+) -> str:
+    """Convert G-code text into an SVG preview string."""
+    moves = _parse_moves(gcode_text)
+
+    all_points: List[Point] = []
+    for move in moves:
+        if len(move.points) < 2:
+            continue
+        all_points.extend(move.points)
+
+    if not all_points:
+        return (
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">'
+            '<rect x="0" y="0" width="10" height="10" fill="white"/>'
+            "</svg>\n"
+        )
+
+    xs = [p[0] for p in all_points]
+    ys_svg = [-p[1] for p in all_points]
+    min_x, max_x = min(xs), max(xs)
+    min_y, max_y = min(ys_svg), max(ys_svg)
+    width = max(1e-6, max_x - min_x)
+    height = max(1e-6, max_y - min_y)
+    margin = max(width, height) * 0.02
+    vb_w = width + 2.0 * margin
+    vb_h = height + 2.0 * margin
+    draw_paths: List[str] = []
+    travel_paths: List[str] = []
+    for move in moves:
+        path_d = _to_svg_path(
+            move.points,
+            min_x=min_x,
+            min_y=min_y,
+            margin=margin,
+        )
+        if not path_d:
+            continue
+        if move.kind == "draw":
+            draw_paths.append(path_d)
+        else:
+            travel_paths.append(path_d)
+
+    lines: List[str] = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        (
+            f'<svg xmlns="http://www.w3.org/2000/svg" '
+            f'width="{_format_num(vb_w)}mm" height="{_format_num(vb_h)}mm" '
+            f'viewBox="0 0 {_format_num(vb_w)} {_format_num(vb_h)}" '
+            f'preserveAspectRatio="xMidYMid meet">'
+        ),
+        '<rect x="0" y="0" width="100%" height="100%" fill="white"/>',
+    ]
+    if travel_paths:
+        lines.append('<g fill="none" stroke="#dddddd" stroke-width="0.20">')
+        for d in travel_paths:
+            lines.append(f'<path d="{d}"/>')
+        lines.append("</g>")
+    if draw_paths:
+        draw_width = max(0.01, float(draw_stroke_width_mm))
+        lines.append(
+            f'<g fill="none" stroke="#111111" stroke-width="{_format_num(draw_width)}">'
+        )
+        for d in draw_paths:
+            lines.append(f'<path d="{d}"/>')
+        lines.append("</g>")
+    lines.append("</svg>")
+    lines.append("")
+    return "\n".join(lines)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI, UploadFile, WebSocket, WebSocketDisconnect, HTTPException, Form, Body
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
-from fastapi.responses import JSONResponse, FileResponse
+from fastapi.responses import JSONResponse, FileResponse, Response
 from contextlib import asynccontextmanager
 import serial
 import serial.tools.list_ports
@@ -40,6 +40,7 @@ from .plotter_models import (
 )
 from .plotter_service import plotter_service, GCODE_SEND_DELAY_SECONDS
 from .gcode_analyzer import analyze_gcode_file
+from .gcode_svg import gcode_to_svg_string
 from .svg_analyzer import analyze_svg_file
 
 # Configure logging
@@ -456,6 +457,47 @@ async def get_project_thumbnail(project_id: str):
     except Exception as e:
         logger.error(f"Get project thumbnail error: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.get("/projects/{project_id}/images/{filename:path}/gcode-preview")
+async def get_project_gcode_preview(project_id: str, filename: str):
+    """Convert a project G-code file into an SVG preview."""
+    try:
+        _ensure_valid_project_id(project_id)
+        project = project_service.get_project(project_id)
+        if not project:
+            raise HTTPException(status_code=404, detail="Project not found")
+
+        if ".." in filename.split("/") or ".." in filename.split("\\"):
+            raise HTTPException(status_code=400, detail="Invalid file path")
+
+        candidate = Path(filename)
+        if candidate.is_absolute() or ".." in candidate.parts:
+            raise HTTPException(status_code=400, detail="Invalid file path")
+
+        ext = candidate.suffix.lower()
+        if ext not in ALLOWED_GCODE_EXTENSIONS:
+            raise HTTPException(status_code=400, detail="File is not a G-code file")
+
+        project_dir = project_service._get_project_directory(project_id).resolve()
+        gcode_path = (project_dir / filename).resolve()
+
+        if project_dir not in gcode_path.parents and project_dir != gcode_path:
+            raise HTTPException(status_code=400, detail="Invalid file path")
+
+        if not gcode_path.exists() or not gcode_path.is_file():
+            raise HTTPException(status_code=404, detail="G-code file not found")
+
+        gcode_text = gcode_path.read_text(encoding="utf-8")
+        svg = gcode_to_svg_string(gcode_text)
+        return Response(content=svg, media_type="image/svg+xml")
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"G-code preview error: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
 
 @app.get("/projects/{project_id}/images/{filename:path}")
 async def get_project_image(project_id: str, filename: str):

--- a/docs/RUNNING_NATIVE_ON_RASPBERRY_PI.md
+++ b/docs/RUNNING_NATIVE_ON_RASPBERRY_PI.md
@@ -126,6 +126,17 @@ uvicorn app.main:app --host 0.0.0.0 --port 8000
 
 Leave this terminal running. The API will be at `http://<pi-ip>:8000`.
 
+**One-command startup (both backend and frontend, keeps running after terminal closes):**
+
+```bash
+cd ~/PolarVortex
+# Set ARDUINO_PORTS (and optionally PV_CONFIG) in backend/.env or export them first
+chmod +x scripts/start_native.sh
+./scripts/start_native.sh
+```
+
+This starts backend and frontend with `nohup` and writes PIDs and logs under `backend/local_storage/log/`. To stop: `kill $(cat backend/local_storage/log/backend.pid) $(cat backend/local_storage/log/frontend.pid)`.
+
 ## 5. Frontend
 
 ### Option A: Development server (recommended for daily use)

--- a/frontend/src/components/EditProject.jsx
+++ b/frontend/src/components/EditProject.jsx
@@ -55,6 +55,7 @@ import {
   getProjectFileText,
   getProjectFileUrl,
   getProjectGcodeAnalysis,
+  getProjectGcodePreviewSvg,
   getProjectSvgAnalysis,
   createProjectThumbnail,
   renameProjectFile,
@@ -220,57 +221,6 @@ function buildAssetSecondaryText(asset) {
   return parts.length ? parts.join(" • ") : undefined;
 }
 
-function parseGcodeForPreview(content) {
-  let x = 0;
-  let y = 0;
-  const segments = [];
-  let bounds = null;
-
-  const lines = content.split(/\r?\n/);
-  for (const rawLine of lines) {
-    const noComment = rawLine.split(";")[0].trim();
-    if (!noComment) continue;
-
-    const cmdMatch = noComment.match(/\bG0?0\b|\bG0?1\b/i);
-    if (!cmdMatch) continue;
-    const cmd = cmdMatch[0].toUpperCase();
-    const penDown = cmd !== "G0" && cmd !== "G00";
-
-    const xMatch = noComment.match(/X(-?\d+(\.\d+)?)/i);
-    const yMatch = noComment.match(/Y(-?\d+(\.\d+)?)/i);
-    const nextX = xMatch ? parseFloat(xMatch[1]) : x;
-    const nextY = yMatch ? parseFloat(yMatch[1]) : y;
-
-    if (Number.isNaN(nextX) || Number.isNaN(nextY)) {
-      continue;
-    }
-
-    if (nextX === x && nextY === y) {
-      continue;
-    }
-
-    segments.push({
-      from: { x, y },
-      to: { x: nextX, y: nextY },
-      penDown,
-    });
-
-    x = nextX;
-    y = nextY;
-
-    bounds = bounds
-      ? {
-          minX: Math.min(bounds.minX, x),
-          maxX: Math.max(bounds.maxX, x),
-          minY: Math.min(bounds.minY, y),
-          maxY: Math.max(bounds.maxY, y),
-        }
-      : { minX: x, maxX: x, minY: y, maxY: y };
-  }
-
-  return { segments, bounds };
-}
-
 export default function EditProject({ currentProject }) {
   const [assets, setAssets] = useState({ images: [], svgs: [], gcode: [] });
   const [loadingAssets, setLoadingAssets] = useState(false);
@@ -303,10 +253,7 @@ export default function EditProject({ currentProject }) {
     error: "",
   });
   const [deletingFile, setDeletingFile] = useState(null);
-  const [gcodeGeometry, setGcodeGeometry] = useState({
-    segments: [],
-    bounds: null,
-  });
+  const [gcodePreviewSvg, setGcodePreviewSvg] = useState("");
   const [convertDialogOpen, setConvertDialogOpen] = useState(false);
   const [convertTarget, setConvertTarget] = useState(null);
   const [convertOptions, setConvertOptions] = useState({
@@ -343,7 +290,6 @@ export default function EditProject({ currentProject }) {
   const [svgDragging, setSvgDragging] = useState(false);
   const [svgDragStart, setSvgDragStart] = useState({ x: 0, y: 0 });
   const svgContainerRef = useRef(null);
-  const gcodeCanvasRef = useRef(null);
   const gcodeContainerRef = useRef(null);
   const [gcodeDragging, setGcodeDragging] = useState(false);
   const [gcodeDragStart, setGcodeDragStart] = useState({ x: 0, y: 0 });
@@ -472,21 +418,24 @@ export default function EditProject({ currentProject }) {
   useEffect(() => {
     if (!selectedAsset || selectedAsset.type !== "gcode" || !currentProject) {
       setGcodePreview({ loading: false, content: "", error: "" });
+      setGcodePreviewSvg("");
       setGcodeAnalysis({ loading: false, data: null, error: "" });
       setSvgAnalysis({ loading: false, data: null, error: "" });
       return;
     }
 
     let cancelled = false;
-    const loadText = async () => {
+    const load = async () => {
       setGcodePreview({ loading: true, content: "", error: "" });
+      setGcodePreviewSvg("");
       try {
-        const content = await getProjectFileText(
-          currentProject.id,
-          selectedAsset.filename
-        );
+        const [content, svg] = await Promise.all([
+          getProjectFileText(currentProject.id, selectedAsset.filename),
+          getProjectGcodePreviewSvg(currentProject.id, selectedAsset.filename),
+        ]);
         if (!cancelled) {
           setGcodePreview({ loading: false, content, error: "" });
+          setGcodePreviewSvg(svg);
         }
       } catch (err) {
         if (!cancelled) {
@@ -495,25 +444,16 @@ export default function EditProject({ currentProject }) {
             content: "",
             error: err.message || "Failed to load file",
           });
+          setGcodePreviewSvg("");
         }
       }
     };
 
-    loadText();
+    load();
     return () => {
       cancelled = true;
     };
   }, [currentProject, selectedAsset]);
-
-  useEffect(() => {
-    if (selectedAsset?.type !== "gcode" || !gcodePreview.content) {
-      setGcodeGeometry({ segments: [], bounds: null });
-      return;
-    }
-
-    const parsed = parseGcodeForPreview(gcodePreview.content);
-    setGcodeGeometry(parsed);
-  }, [selectedAsset, gcodePreview.content]);
 
   useEffect(() => {
     if (selectedAsset?.type !== "svg") {
@@ -972,118 +912,6 @@ export default function EditProject({ currentProject }) {
     setGcodePan({ x: 0, y: 0 });
   };
 
-  // Draw G-code preview on canvas for performance
-  useEffect(() => {
-    const canvas = gcodeCanvasRef.current;
-    if (!canvas) return;
-
-    const ctx = canvas.getContext("2d");
-    const printableSegments = (gcodeGeometry.segments || []).filter(
-      (seg) => seg.penDown
-    );
-
-    const width = 640;
-    const height = 420;
-    canvas.width = width;
-    canvas.height = height;
-
-    const fillBackground = () => {
-      ctx.clearRect(0, 0, width, height);
-      ctx.fillStyle = "#999999";
-      ctx.fillRect(0, 0, width, height);
-    };
-
-    if (!printableSegments.length) {
-      fillBackground();
-      return;
-    }
-
-    const calcBounds = (segments) => {
-      if (!segments.length) return null;
-      return segments.reduce(
-        (acc, seg) => ({
-          minX: Math.min(acc.minX, seg.from.x, seg.to.x),
-          maxX: Math.max(acc.maxX, seg.from.x, seg.to.x),
-          minY: Math.min(acc.minY, seg.from.y, seg.to.y),
-          maxY: Math.max(acc.maxY, seg.from.y, seg.to.y),
-        }),
-        {
-          minX: Infinity,
-          maxX: -Infinity,
-          minY: Infinity,
-          maxY: -Infinity,
-        }
-      );
-    };
-
-    const bounds = calcBounds(printableSegments);
-    const paperWidth = defaultPaper ? Number(defaultPaper.width) || 0 : 0;
-    const paperHeight = defaultPaper ? Number(defaultPaper.height) || 0 : 0;
-    const paperBox =
-      paperWidth > 0 && paperHeight > 0
-        ? {
-            minX: -paperWidth / 2,
-            maxX: paperWidth / 2,
-            minY: -paperHeight / 2,
-            maxY: paperHeight / 2,
-          }
-        : null;
-
-    const combinedBounds = bounds
-      ? {
-          minX: Math.min(bounds.minX, paperBox ? paperBox.minX : bounds.minX),
-          maxX: Math.max(bounds.maxX, paperBox ? paperBox.maxX : bounds.maxX),
-          minY: Math.min(bounds.minY, paperBox ? paperBox.minY : bounds.minY),
-          maxY: Math.max(bounds.maxY, paperBox ? paperBox.maxY : bounds.maxY),
-        }
-      : paperBox;
-
-    const { minX, maxX, minY, maxY } = combinedBounds || bounds;
-    const padding = 16;
-    const spanX = Math.max(maxX - minX, 1);
-    const spanY = Math.max(maxY - minY, 1);
-    const scaleX = (width - padding * 2) / spanX;
-    const scaleY = (height - padding * 2) / spanY;
-    const baseScale = Math.min(scaleX, scaleY);
-    const scale = baseScale * gcodeZoom;
-    const centerX = (minX + maxX) / 2;
-    const centerY = (minY + maxY) / 2;
-
-    const mapPoint = (x, y) => ({
-      // Positive pan moves the drawing in the same direction as the mouse drag
-      x: width / 2 + (x - centerX + gcodePan.x) * scale,
-      y: height / 2 - (y - centerY - gcodePan.y) * scale,
-    });
-
-    fillBackground();
-
-    // Draw paper outline
-    if (paperBox) {
-      const tl = mapPoint(paperBox.minX, paperBox.minY);
-      const br = mapPoint(paperBox.maxX, paperBox.maxY);
-      ctx.save();
-      ctx.strokeStyle = "#8bc34a";
-      ctx.lineWidth = 1.5;
-      ctx.setLineDash([6, 4]);
-      ctx.strokeRect(tl.x, tl.y, br.x - tl.x, br.y - tl.y);
-      ctx.restore();
-    }
-
-    // Draw segments in a single path for speed
-    ctx.save();
-    ctx.strokeStyle = "#1976d2";
-    ctx.lineWidth = 1.5;
-    ctx.beginPath();
-    for (const seg of printableSegments) {
-      const from = mapPoint(seg.from.x, seg.from.y);
-      const to = mapPoint(seg.to.x, seg.to.y);
-      ctx.moveTo(from.x, from.y);
-      ctx.lineTo(to.x, to.y);
-    }
-    ctx.stroke();
-    ctx.restore();
-  }, [gcodeGeometry, gcodeZoom, gcodePan, defaultPaper]);
-
   // SVG pan/zoom handlers
   const handleSvgMouseDown = (e) => {
     if (e.button !== 0) return; // Only left mouse button
@@ -1244,85 +1072,24 @@ export default function EditProject({ currentProject }) {
   };
 
   const renderGcodePlot = () => {
-    const printableSegments = (gcodeGeometry.segments || []).filter(
-      (seg) => seg.penDown
-    );
-
-    const calcBounds = (segments) => {
-      if (!segments.length) return null;
-      return segments.reduce(
-        (acc, seg) => ({
-          minX: Math.min(acc.minX, seg.from.x, seg.to.x),
-          maxX: Math.max(acc.maxX, seg.from.x, seg.to.x),
-          minY: Math.min(acc.minY, seg.from.y, seg.to.y),
-          maxY: Math.max(acc.maxY, seg.from.y, seg.to.y),
-        }),
-        {
-          minX: Infinity,
-          maxX: -Infinity,
-          minY: Infinity,
-          maxY: -Infinity,
-        }
-      );
-    };
-
-    const bounds = calcBounds(printableSegments);
-
-    const paperWidth = defaultPaper ? Number(defaultPaper.width) || 0 : 0;
-    const paperHeight = defaultPaper ? Number(defaultPaper.height) || 0 : 0;
-    const paperBox =
-      paperWidth > 0 && paperHeight > 0
-        ? {
-            minX: -paperWidth / 2,
-            maxX: paperWidth / 2,
-            minY: -paperHeight / 2,
-            maxY: paperHeight / 2,
-          }
-        : null;
-
-    // Expand bounds to include paper rectangle so both fit the viewport
-    const combinedBounds = bounds
-      ? {
-          minX: Math.min(bounds.minX, paperBox ? paperBox.minX : bounds.minX),
-          maxX: Math.max(bounds.maxX, paperBox ? paperBox.maxX : bounds.maxX),
-          minY: Math.min(bounds.minY, paperBox ? paperBox.minY : bounds.minY),
-          maxY: Math.max(bounds.maxY, paperBox ? paperBox.maxY : bounds.maxY),
-        }
-      : paperBox;
-
-    if (!bounds || printableSegments.length === 0) {
+    if (gcodePreview.loading) {
       return (
-        <Alert severity="info" sx={{ mb: 2 }}>
-          No printable moves found (only travel moves present).
-        </Alert>
+        <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 2 }}>
+          <CircularProgress size={18} />
+          <Typography variant="body2">Loading G-code preview…</Typography>
+        </Stack>
       );
     }
 
-    const { minX, maxX, minY, maxY } = combinedBounds || bounds;
-    const width = 640;
-    const height = 420;
-    const padding = 16;
-    const spanX = Math.max(maxX - minX, 1);
-    const spanY = Math.max(maxY - minY, 1);
-    const scaleX = (width - padding * 2) / spanX;
-    const scaleY = (height - padding * 2) / spanY;
-    const baseScale = Math.min(scaleX, scaleY);
-    const scale = baseScale * gcodeZoom;
-    const centerX = (minX + maxX) / 2;
-    const centerY = (minY + maxY) / 2;
-
-    const mapPoint = (x, y) => ({
-      x: width / 2 + (x - centerX - gcodePan.x) * scale,
-      // Flip Y so higher Y is up visually
-      y: height / 2 - (y - centerY - gcodePan.y) * scale,
-    });
+    if (!gcodePreviewSvg) {
+      return null;
+    }
 
     return (
       <Box sx={{ mb: 2 }}>
         <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1 }}>
           <CodeIcon color="primary" />
           <Typography variant="subtitle1">G-code Plot Preview</Typography>
-          <Chip label={`${printableSegments.length} segments`} size="small" />
           <Box sx={{ flexGrow: 1 }} />
           <Button
             size="small"
@@ -1360,14 +1127,26 @@ export default function EditProject({ currentProject }) {
               cursor: gcodeDragging ? "grabbing" : "grab",
               userSelect: "none",
               overflow: "hidden",
+              bgcolor: "#bdbdbd",
+              borderRadius: 1,
+              "& > div": {
+                display: "flex",
+                justifyContent: "center",
+                alignItems: "center",
+                "& svg": {
+                  display: "block",
+                  maxWidth: "100%",
+                  maxHeight: "440px",
+                  transform: `translate(${gcodePan.x}px, ${gcodePan.y}px) scale(${gcodeZoom})`,
+                  transformOrigin: "center center",
+                  transition: gcodeDragging ? "none" : "transform 0.1s ease-out",
+                },
+              },
             }}
           >
-            <canvas
-              ref={gcodeCanvasRef}
-              style={{
-                width: "100%",
-                height: "100%",
-              }}
+            <div
+              dangerouslySetInnerHTML={{ __html: gcodePreviewSvg }}
+              style={{ width: "100%", display: "flex", justifyContent: "center" }}
             />
           </Box>
         </Paper>

--- a/frontend/src/components/MenuBar.jsx
+++ b/frontend/src/components/MenuBar.jsx
@@ -25,12 +25,18 @@ import {
 import React from "react";
 import logoImage from "../assets/PolarVortexLogo_small.png";
 
+/** Fallback icon when logo image fails to load (e.g. wrong path in build or dev). */
+const LogoFallbackIcon = (
+  <TimelineIcon sx={{ fontSize: 40, color: "inherit", display: "block" }} />
+);
+
 /**
  * MenuBar component for PolarVortex
  * Provides navigation between different sections of the application
  */
 export default function MenuBar({ currentView, onNavigate, currentProject }) {
   const [drawerOpen, setDrawerOpen] = React.useState(false);
+  const [logoError, setLogoError] = React.useState(false);
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
 
@@ -92,16 +98,23 @@ export default function MenuBar({ currentView, onNavigate, currentProject }) {
               minWidth: 0,
             }}
           >
-            <img
-              src={logoImage}
-              alt="PolarVortex Logo"
-              style={{
-                height: "40px",
-                width: "auto",
-                marginRight: "12px",
-                filter: "brightness(0) invert(1)", // Make logo white for dark background
-              }}
-            />
+            {logoError ? (
+              <Box sx={{ mr: 1.5, display: "flex", alignItems: "center" }}>
+                {LogoFallbackIcon}
+              </Box>
+            ) : (
+              <img
+                src={logoImage}
+                alt="PolarVortex Logo"
+                onError={() => setLogoError(true)}
+                style={{
+                  height: "40px",
+                  width: "auto",
+                  marginRight: "12px",
+                  filter: "brightness(0) invert(1)", // Make logo white for dark background
+                }}
+              />
+            )}
             <Typography variant="h6" component="div">
               PolarVortex
             </Typography>
@@ -167,11 +180,18 @@ export default function MenuBar({ currentView, onNavigate, currentProject }) {
               borderColor: "divider",
             }}
           >
-            <img
-              src={logoImage}
-              alt="PolarVortex Logo"
-              style={{ height: "50px", width: "auto" }}
-            />
+            {logoError ? (
+              <Box sx={{ display: "flex", justifyContent: "center", color: "primary.main" }}>
+                <TimelineIcon sx={{ fontSize: 50 }} />
+              </Box>
+            ) : (
+              <img
+                src={logoImage}
+                alt="PolarVortex Logo"
+                onError={() => setLogoError(true)}
+                style={{ height: "50px", width: "auto" }}
+              />
+            )}
             <Typography variant="h6" sx={{ mt: 1, color: "primary.main" }}>
               PolarVortex
             </Typography>

--- a/frontend/src/services/apiService.js
+++ b/frontend/src/services/apiService.js
@@ -154,6 +154,16 @@ export async function getProjectFileText(projectId, filename) {
   return text;
 }
 
+export async function getProjectGcodePreviewSvg(projectId, filename) {
+  const safePath = (filename || "").split("/").map(encodeURIComponent).join("/");
+  const url = `${BASE_URL}/projects/${projectId}/images/${safePath}/gcode-preview`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to load G-code preview: ${response.statusText}`);
+  }
+  return response.text();
+}
+
 export async function deleteProjectFile(projectId, filename) {
   const safePath = (filename || "").split("/").map(encodeURIComponent).join("/");
   const url = `${BASE_URL}/projects/${projectId}/images/${safePath}`;

--- a/scripts/start_native.sh
+++ b/scripts/start_native.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Start PolarVortex backend and frontend natively with nohup so they keep
+# running after the terminal exits. See docs/RUNNING_NATIVE_ON_RASPBERRY_PI.md.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+BACKEND_DIR="$PROJECT_ROOT/backend"
+FRONTEND_DIR="$PROJECT_ROOT/frontend"
+LOG_DIR="${PV_LOG_DIR:-$BACKEND_DIR/local_storage/log}"
+mkdir -p "$LOG_DIR"
+
+# Venv activate: Windows uses Scripts, Linux/macOS use bin
+if [ -f "$BACKEND_DIR/.venv/Scripts/activate" ]; then
+  VENV_ACTIVATE="$BACKEND_DIR/.venv/Scripts/activate"
+elif [ -f "$BACKEND_DIR/.venv/bin/activate" ]; then
+  VENV_ACTIVATE="$BACKEND_DIR/.venv/bin/activate"
+else
+  echo "Error: backend virtualenv not found. Create it with: cd backend && python -m venv .venv && pip install -r requirements.txt"
+  exit 1
+fi
+
+BACKEND_LOG="$LOG_DIR/backend.log"
+FRONTEND_LOG="$LOG_DIR/frontend.log"
+BACKEND_PID_FILE="$LOG_DIR/backend.pid"
+FRONTEND_PID_FILE="$LOG_DIR/frontend.pid"
+
+# Load backend env if present (PV_CONFIG, ARDUINO_PORTS, etc.)
+if [ -f "$BACKEND_DIR/.env" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "$BACKEND_DIR/.env"
+  set +a
+fi
+
+# Defaults if not set
+export PV_CONFIG="${PV_CONFIG:-$BACKEND_DIR/local_storage/config/config.yaml}"
+export ARDUINO_PORTS="${ARDUINO_PORTS:-/dev/ttyACM0,/dev/ttyUSB0}"
+export BACKEND_HOST="${BACKEND_HOST:-0.0.0.0}"
+export BACKEND_PORT="${BACKEND_PORT:-8000}"
+export VITE_API_BASE_URL="${VITE_API_BASE_URL:-http://localhost:$BACKEND_PORT}"
+export VITE_WS_BASE_URL="${VITE_WS_BASE_URL:-ws://localhost:$BACKEND_PORT}"
+
+echo "PolarVortex native startup"
+echo "  Backend:  $BACKEND_HOST:$BACKEND_PORT (log: $BACKEND_LOG)"
+echo "  Frontend: Vite dev server (log: $FRONTEND_LOG)"
+echo ""
+
+# Start backend (PID captured inside subshell so we get uvicorn, not the shell)
+if [ -f "$BACKEND_PID_FILE" ] && kill -0 "$(cat "$BACKEND_PID_FILE")" 2>/dev/null; then
+  echo "Backend already running (PID $(cat "$BACKEND_PID_FILE")). Skipping."
+else
+  (
+    cd "$BACKEND_DIR"
+    source "$VENV_ACTIVATE"
+    nohup uvicorn app.main:app --host "$BACKEND_HOST" --port "$BACKEND_PORT" >> "$BACKEND_LOG" 2>&1 &
+    echo $! > "$BACKEND_PID_FILE"
+  )
+  echo "Backend started (PID $(cat "$BACKEND_PID_FILE"))."
+fi
+
+# Brief pause so backend is up before frontend tries to connect
+sleep 2
+
+# Start frontend (Vite dev server; PID is npm, which is enough to stop the server)
+if [ -f "$FRONTEND_PID_FILE" ] && kill -0 "$(cat "$FRONTEND_PID_FILE")" 2>/dev/null; then
+  echo "Frontend already running (PID $(cat "$FRONTEND_PID_FILE")). Skipping."
+else
+  (
+    cd "$FRONTEND_DIR"
+    export VITE_API_BASE_URL VITE_WS_BASE_URL
+    nohup npm run dev >> "$FRONTEND_LOG" 2>&1 &
+    echo $! > "$FRONTEND_PID_FILE"
+  )
+  echo "Frontend started (PID $(cat "$FRONTEND_PID_FILE"))."
+fi
+
+echo ""
+echo "Both processes are running in the background. You can close this terminal."
+echo "  Backend:  http://localhost:$BACKEND_PORT"
+echo "  Frontend: http://localhost:5173 (Vite dev)"
+echo "  Logs:     $BACKEND_LOG  $FRONTEND_LOG"
+echo "  PIDs:     $BACKEND_PID_FILE  $FRONTEND_PID_FILE"
+echo "To stop later: kill \$(cat $BACKEND_PID_FILE) \$(cat $FRONTEND_PID_FILE)"


### PR DESCRIPTION
Replaces the limited canvas-based G-code preview with Scrible's robust G-code-to-SVG conversion.

**Backend:**
- New `gcode_svg.py` module with `gcode_to_svg_string()` (adapted from Scrible)
- New endpoint `GET /projects/{id}/images/{filename}/gcode-preview` returns SVG

**Frontend:**
- Fetches SVG preview from backend instead of parsing client-side
- Replaces canvas with SVG display (resolution-independent, zoom/pan preserved)

**Improvements:**
- Supports G2/G3 arcs (previously only G0/G1)
- Supports G90/G91 absolute/relative modes
- Supports M280 pen up/down commands
- Draw paths in black, travel paths in gray

Made with [Cursor](https://cursor.com)